### PR TITLE
Add urlencoded parser helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,16 @@ docker run -d \
 
 - `GET /` - Health check endpoint
 - `POST /webhook` - Webhook endpoint for AMOCRM
+## Parsing application/x-www-form-urlencoded
+
+If you log webhook bodies as raw strings, decode them using the helper in `src/formParser.js`:
+
+```js
+const { parseFormEncoded } = require("./src/formParser");
+const data = parseFormEncoded(rawBody);
+console.log(JSON.stringify(data, null, 2));
+```
+
 
 ## Environment Variables
 

--- a/src/formParser.js
+++ b/src/formParser.js
@@ -1,0 +1,12 @@
+const qs = require('querystring');
+
+function parseFormEncoded(formString) {
+  if (typeof formString !== 'string') {
+    throw new TypeError('Expected formString to be a string');
+  }
+
+  return qs.parse(formString);
+}
+
+module.exports = { parseFormEncoded };
+


### PR DESCRIPTION
## Summary
- add `parseFormEncoded` helper for decoding application/x-www-form-urlencoded
- document the helper in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685135c83ecc832c9644f0db478c8195