### PR TITLE
Add global error handlers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,15 @@ const cors = require('cors');
 const morgan = require('morgan');
 const { processWebhook } = require('./webhookHandler');
 
+// Prevent the process from crashing on unexpected errors
+process.on('unhandledRejection', (reason, promise) => {
+  console.error('Unhandled Rejection at:', promise, 'reason:', reason);
+});
+
+process.on('uncaughtException', (err) => {
+  console.error('Uncaught Exception thrown:', err);
+});
+
 const app = express();
 const PORT = process.env.PORT || 3012;
 const WEBHOOK_PATH = process.env.WEBHOOK_PATH || '/webhook';


### PR DESCRIPTION
## Summary
- log `unhandledRejection` and `uncaughtException` to keep server running

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6852c6d32c90832c8ef442c68657dd57