### PR TITLE
Add test-webhook utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,5 @@ bower_components
 ehthumbs.db
 Thumbs.db
 data/
+!data/body-test.json
+

--- a/README.md
+++ b/README.md
@@ -77,6 +77,16 @@ docker run -d \
 
 - `GET /` - Health check endpoint
 - `POST /webhook` - Webhook endpoint for AMOCRM
+
+## Testing Webhooks
+
+Use `npm run test-webhook` to process a sample webhook. By default it loads data from `./data/body-test.json`.
+To specify another file, pass the path as an argument:
+
+```bash
+npm run test-webhook -- <path-to-json>
+```
+
 ## Parsing application/x-www-form-urlencoded
 
 If you log webhook bodies as raw strings, decode them using the helper in `src/formParser.js`:

--- a/data/body-test.json
+++ b/data/body-test.json
@@ -1,0 +1,4 @@
+{
+  "account": { "_links": { "self": "https://example.amocrm.com" } },
+  "leads": { "add": [ { "id": 123456 } ] }
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "node src/index.js",
     "dev": "nodemon src/index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "test-webhook": "node src/testWebhook.js"
   },
   "keywords": [
     "amocrm",

--- a/src/testWebhook.js
+++ b/src/testWebhook.js
@@ -1,0 +1,22 @@
+require('dotenv').config();
+const fs = require('fs');
+const path = require('path');
+const { processWebhook } = require('./webhookHandler');
+
+async function main() {
+  const argPath = process.argv[2];
+  const bodyPath = argPath ? path.resolve(argPath) : path.join(__dirname, '..', 'data', 'body-test.json');
+
+  const bodyData = fs.readFileSync(bodyPath, 'utf8');
+  const body = JSON.parse(bodyData);
+
+  try {
+    const result = await processWebhook({ body });
+    console.log('Webhook processed successfully:', JSON.stringify(result, null, 2));
+  } catch (err) {
+    console.error('Error processing webhook:', err);
+    process.exitCode = 1;
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- allow committing test webhook data file
- add script to process a webhook from `./data/body-test.json`
- document usage in README

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node src/testWebhook.js` *(fails: AMOCRM access token is required)*

------
https://chatgpt.com/codex/tasks/task_e_6853ecc0ecac832c9976deb44e0f8a5a