### PR TITLE
Improve queue retry logic and webhook error handling

### DIFF
--- a/src/queue.js
+++ b/src/queue.js
@@ -63,9 +63,16 @@ async function processQueue() {
   processing = true;
   try {
     let row = db
-      .prepare('SELECT * FROM queue WHERE attempts < ? ORDER BY id LIMIT 1')
+      .prepare(
+        'SELECT * FROM queue WHERE attempts < ? ORDER BY attempts, created_at LIMIT 1'
+      )
       .get(MAX_ATTEMPTS);
     while (row) {
+      if (row.attempts > 0) {
+        const sleepTime = DELAY * (row.attempts ** 2) * 2;
+        console.log(`Retrying row ${row.id}: attempts=${row.attempts}, sleep=${sleepTime}ms`);
+        await new Promise((r) => setTimeout(r, sleepTime));
+      }
       try {
         const data = JSON.parse(row.body);
         const response = await processWebhook({ body: data });
@@ -87,7 +94,9 @@ async function processQueue() {
       }
       await new Promise((r) => setTimeout(r, DELAY));
       row = db
-        .prepare('SELECT * FROM queue WHERE attempts < ? ORDER BY id LIMIT 1')
+        .prepare(
+          'SELECT * FROM queue WHERE attempts < ? ORDER BY attempts, created_at LIMIT 1'
+        )
         .get(MAX_ATTEMPTS);
     }
   } finally {

--- a/src/webhookHandler.js
+++ b/src/webhookHandler.js
@@ -194,7 +194,6 @@ async function processWebhook(inputData) {
 
   if (!lead.name) {
     console.error(`Failed to retrieve lead details for lead ID: ${leadId}`);
-    // throw new Error(`Unable to process webhook: Lead ${leadId} not found or inaccessible`);
   }
 
   // Prepare task parameters
@@ -208,7 +207,14 @@ async function processWebhook(inputData) {
   // Create task in Planfix
   if (createTaskUrl) {
     const task = await createPlanfixTask(taskParams, agentToken, createTaskUrl);
+    if (!lead.name) {
+      throw new Error(`Lead ${leadId} has no name`);
+    }
     return { body, lead, taskParams, task };
+  }
+
+  if (!lead.name) {
+    throw new Error(`Lead ${leadId} has no name`);
   }
 
   return { body, lead, taskParams };


### PR DESCRIPTION
## Summary
- process queue items by attempts and age
- add exponential backoff delay with logs for retries
- throw an error when a lead has no name after creating Planfix task

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6853f92e8094832ca15017f311ef6fc7