### PR TITLE
Refactor async retries

### DIFF
--- a/src/formParser.js
+++ b/src/formParser.js
@@ -1,12 +1,11 @@
-const qs = require('querystring');
+const qs = require("querystring");
 
 function parseFormEncoded(formString) {
-  if (typeof formString !== 'string') {
-    throw new TypeError('Expected formString to be a string');
+  if (typeof formString !== "string") {
+    throw new TypeError("Expected formString to be a string");
   }
 
   return qs.parse(formString);
 }
 
 module.exports = { parseFormEncoded };
-

--- a/src/index.js
+++ b/src/index.js
@@ -52,12 +52,11 @@ app.use((err, req, res, next) => {
   });
 });
 
-
 if (require.main === module) {
   app.listen(PORT, () => {
     console.log(`Server is running on http://localhost:${PORT}`);
     console.log("Environment:", process.env.NODE_ENV || "development");
-    processQueue().catch((e) => console.error('Startup queue error:', e));
+    processQueue().catch((e) => console.error("Startup queue error:", e));
   });
 }
 

--- a/src/queue.js
+++ b/src/queue.js
@@ -9,6 +9,8 @@ const DB_PATH = path.join(DB_DIR, 'webhooks.db');
 const MAX_ATTEMPTS = 12;
 const DELAY = 1000;
 
+let nextTimer = null;
+
 fs.mkdirSync(DB_DIR, { recursive: true });
 
 const db = new Database(DB_PATH);
@@ -21,7 +23,8 @@ CREATE TABLE IF NOT EXISTS queue (
   body TEXT,
   created_at INTEGER,
   attempts INTEGER DEFAULT 0,
-  last_error TEXT
+  last_error TEXT,
+  next_attempt INTEGER
 );
 CREATE TABLE IF NOT EXISTS processed (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -35,6 +38,12 @@ CREATE TABLE IF NOT EXISTS processed (
 );
 `;
 db.exec(initSql);
+
+// Add next_attempt column if this database was created before it existed
+const columns = db.prepare('PRAGMA table_info(queue)').all();
+if (!columns.find(c => c.name === 'next_attempt')) {
+  db.exec('ALTER TABLE queue ADD COLUMN next_attempt INTEGER DEFAULT 0');
+}
 
 function checksum(obj) {
   const str = typeof obj === 'string' ? obj : JSON.stringify(obj);
@@ -51,62 +60,83 @@ function addWebhook(body) {
     return false; // duplicate
   }
   db.prepare(
-    'INSERT INTO queue (checksum, body, created_at) VALUES (?,?,?)'
-  ).run(sum, JSON.stringify(body), Date.now());
+    'INSERT INTO queue (checksum, body, created_at, next_attempt) VALUES (?,?,?,?)'
+  ).run(sum, JSON.stringify(body), Date.now(), Date.now());
   processQueue().catch((e) => console.error('Queue processing error:', e));
   return true;
 }
 
 let processing = false;
+
+function scheduleNext() {
+  if (nextTimer) clearTimeout(nextTimer);
+  const row = db
+    .prepare(
+      'SELECT next_attempt FROM queue WHERE attempts < ? ORDER BY next_attempt LIMIT 1'
+    )
+    .get(MAX_ATTEMPTS);
+  if (row) {
+    const delay = Math.max(0, row.next_attempt - Date.now());
+    nextTimer = setTimeout(() => {
+      nextTimer = null;
+      processQueue().catch((e) => console.error('Queue processing error:', e));
+    }, delay);
+  }
+}
+
+async function handleRow(row) {
+  try {
+    const data = JSON.parse(row.body);
+    const response = await processWebhook({ body: data });
+    db.prepare(
+      'INSERT INTO processed (checksum, body, created_at, processed_at, attempts, response) VALUES (?,?,?,?,?,?)'
+    ).run(
+      row.checksum,
+      row.body,
+      row.created_at,
+      Date.now(),
+      row.attempts + 1,
+      JSON.stringify(response)
+    );
+    db.prepare('DELETE FROM queue WHERE id=?').run(row.id);
+  } catch (err) {
+    const attempts = row.attempts + 1;
+    const sleepTime = DELAY * (row.attempts ** 3) * 2;
+    const nextAttempt = Date.now() + sleepTime;
+    console.log(
+      `Retrying row ${row.id}: attempts=${attempts - 1}, sleep=${sleepTime}ms`
+    );
+    db.prepare(
+      'UPDATE queue SET attempts=?, last_error=?, next_attempt=? WHERE id=?'
+    ).run(attempts, err.message, nextAttempt, row.id);
+  }
+}
+
 async function processQueue() {
   if (processing) return;
   processing = true;
   try {
-    // Log queue size if greater than 1
     const queueSize = db.prepare('SELECT COUNT(*) as count FROM queue WHERE attempts < ?').get(MAX_ATTEMPTS).count;
     if (queueSize > 1) {
       console.log(`Queue size: ${queueSize}`);
     }
-    
+
     let row = db
       .prepare(
-        'SELECT * FROM queue WHERE attempts < ? ORDER BY attempts, created_at LIMIT 1'
+        'SELECT * FROM queue WHERE attempts < ? AND next_attempt <= ? ORDER BY attempts, created_at LIMIT 1'
       )
-      .get(MAX_ATTEMPTS);
+      .get(MAX_ATTEMPTS, Date.now());
     while (row) {
-      if (row.attempts > 0) {
-        const sleepTime = DELAY * (row.attempts ** 3) * 2; // 2, 16, 54, 128, 250, 432, 686, 1024, 1458, 2000
-        console.log(`Retrying row ${row.id}: attempts=${row.attempts}, sleep=${sleepTime}ms`);
-        await new Promise((r) => setTimeout(r, sleepTime));
-      }
-      try {
-        const data = JSON.parse(row.body);
-        const response = await processWebhook({ body: data });
-        db.prepare(
-          'INSERT INTO processed (checksum, body, created_at, processed_at, attempts, response) VALUES (?,?,?,?,?,?)'
-        ).run(
-          row.checksum,
-          row.body,
-          row.created_at,
-          Date.now(),
-          row.attempts + 1,
-          JSON.stringify(response)
-        );
-        db.prepare('DELETE FROM queue WHERE id=?').run(row.id);
-      } catch (err) {
-        db.prepare(
-          'UPDATE queue SET attempts=attempts+1, last_error=? WHERE id=?'
-        ).run(err.message, row.id);
-      }
-      await new Promise((r) => setTimeout(r, DELAY));
+      await handleRow(row);
       row = db
         .prepare(
-          'SELECT * FROM queue WHERE attempts < ? ORDER BY attempts, created_at LIMIT 1'
+          'SELECT * FROM queue WHERE attempts < ? AND next_attempt <= ? ORDER BY attempts, created_at LIMIT 1'
         )
-        .get(MAX_ATTEMPTS);
+        .get(MAX_ATTEMPTS, Date.now());
     }
   } finally {
     processing = false;
+    scheduleNext();
   }
 }
 

--- a/src/testWebhook.js
+++ b/src/testWebhook.js
@@ -1,25 +1,30 @@
-require('dotenv').config();
-const fs = require('fs');
-const path = require('path');
-const { processWebhook } = require('./webhookHandler');
+require("dotenv").config();
+const fs = require("fs");
+const path = require("path");
+const { processWebhook } = require("./webhookHandler");
 
 async function main() {
   const argPath = process.argv[2];
-  const bodyPath = argPath ? path.resolve(argPath) : path.join(__dirname, '..', 'data', 'body-test.json');
+  const bodyPath = argPath
+    ? path.resolve(argPath)
+    : path.join(__dirname, "..", "data", "body-test.json");
   if (!fs.existsSync(bodyPath)) {
     console.error(`File not found: ${bodyPath}`);
     process.exitCode = 1;
     return;
   }
 
-  const bodyData = fs.readFileSync(bodyPath, 'utf8');
+  const bodyData = fs.readFileSync(bodyPath, "utf8");
   const body = JSON.parse(bodyData);
 
   try {
     const result = await processWebhook({ body });
-    console.log('Webhook processed successfully:', JSON.stringify(result, null, 2));
+    console.log(
+      "Webhook processed successfully:",
+      JSON.stringify(result, null, 2)
+    );
   } catch (err) {
-    console.error('Error processing webhook:', err);
+    console.error("Error processing webhook:", err);
     process.exitCode = 1;
   }
 }

--- a/src/webhookHandler.js
+++ b/src/webhookHandler.js
@@ -169,7 +169,7 @@ async function processWebhook(inputData) {
   if (!token) throw new Error("AMOCRM access token is required");
   if (!agentToken) throw new Error("AGENT_TOKEN is required");
 
-  console.log('body: ', JSON.stringify(body));
+  console.log('processWebhook, lead: ', body.leads?.add?.[0], 'body: ', JSON.stringify(body));
   // Access the nested properties directly from the object structure
   const baseUrl = (body.account?._links?.self || '').replace(/\/$/, '');
   const leadId = body.leads?.add?.[0]?.id;

--- a/tests/formParser.test.js
+++ b/tests/formParser.test.js
@@ -1,14 +1,14 @@
-import { describe, it, expect } from 'vitest';
-import { parseFormEncoded } from '../src/formParser';
+import { describe, it, expect } from "vitest";
+import { parseFormEncoded } from "../src/formParser";
 
-describe('parseFormEncoded', () => {
-  it('parses a urlencoded string', () => {
-    const str = 'a=1&b=hello%20world';
+describe("parseFormEncoded", () => {
+  it("parses a urlencoded string", () => {
+    const str = "a=1&b=hello%20world";
     const result = parseFormEncoded(str);
-    expect(result).toEqual({ a: '1', b: 'hello world' });
+    expect(result).toEqual({ a: "1", b: "hello world" });
   });
 
-  it('throws on non-string input', () => {
+  it("throws on non-string input", () => {
     expect(() => parseFormEncoded(null)).toThrow(TypeError);
   });
 });

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,9 +1,9 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import request from 'supertest';
-import app from '../src/index.js';
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import request from "supertest";
+import app from "../src/index.js";
 let server;
 
-describe('index.js', () => {
+describe("index.js", () => {
   beforeAll(async () => {
     server = app.listen(0);
   });
@@ -12,9 +12,9 @@ describe('index.js', () => {
     await new Promise((resolve) => server.close(resolve));
   });
 
-  it('responds to GET / with status ok', async () => {
-    const res = await request(server).get('/');
+  it("responds to GET / with status ok", async () => {
+    const res = await request(server).get("/");
     expect(res.statusCode).toBe(200);
-    expect(res.body).toHaveProperty('status', 'ok');
+    expect(res.body).toHaveProperty("status", "ok");
   });
 });


### PR DESCRIPTION
## Summary
- support `next_attempt` column for asynchronous retries
- schedule only failed rows without blocking queue

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68545b25e6c8832cb7be76000ac54d24