### PR TITLE
Add file logger

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+require("./logger");
 require("dotenv").config();
 const express = require("express");
 const cors = require("cors");

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,0 +1,37 @@
+const fs = require('fs');
+const path = require('path');
+
+const LOG_DIR = path.join(__dirname, '..', 'data');
+const LOG_PATH = path.join(LOG_DIR, 'app.log');
+
+fs.mkdirSync(LOG_DIR, { recursive: true });
+
+function write(level, messages) {
+  const line = `${new Date().toISOString()} ${level.toUpperCase()} ${messages.join(' ')}\n`;
+  try {
+    fs.appendFileSync(LOG_PATH, line);
+  } catch (err) {
+    process.stderr.write(`Failed to write log: ${err.message}\n`);
+  }
+}
+
+const originalLog = console.log.bind(console);
+const originalError = console.error.bind(console);
+const originalWarn = console.warn.bind(console);
+
+console.log = (...args) => {
+  write('info', args.map(String));
+  originalLog(...args);
+};
+
+console.error = (...args) => {
+  write('error', args.map(String));
+  originalError(...args);
+};
+
+console.warn = (...args) => {
+  write('warn', args.map(String));
+  originalWarn(...args);
+};
+
+module.exports = { write };

--- a/src/testWebhook.js
+++ b/src/testWebhook.js
@@ -1,3 +1,4 @@
+require("./logger");
 require("dotenv").config();
 const fs = require("fs");
 const path = require("path");


### PR DESCRIPTION
## Summary
- add `logger.js` to capture console output and write to `data/app.log`
- initialize logger in the server and test webhook script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68553cd46708832c8fe7a7532f6cccfd