### PR TITLE
Refactor into ingest/worker services with monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,15 @@ This service receives webhooks from AMOCRM when new leads are created and forwar
 npm run dev
 ```
 
-The server will start on `http://localhost:3012`
+The ingest server will start on `http://localhost:3012`
 
 ### Production
 
+Run the queue worker and the ingest service separately:
+
 ```bash
-npm start
+npm start        # start the worker
+npm run ingest   # start the webhook collector
 ```
 
 ## Docker
@@ -53,15 +56,15 @@ npm start
 docker build -t amocrm-to-planfix .
 ```
 
-### Run the Docker container
+### Docker Compose
+
+To run the ingest service, worker and monitoring stack use docker-compose:
 
 ```bash
-docker run -d \
-  --name amocrm-to-planfix \
-  -p 3012:3012 \
-  --env-file .env \
-  amocrm-to-planfix
+docker compose up -d
 ```
+
+Grafana will be available on `http://localhost:3000` and Loki on port `3100`.
 
 ## Webhook Configuration in AMOCRM
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,42 @@
+version: '3'
+services:
+  ingest:
+    build: .
+    command: npm run ingest
+    volumes:
+      - ./data:/usr/src/app/data
+    ports:
+      - "3012:3012"
+    environment:
+      - NODE_ENV=production
+
+  worker:
+    build: .
+    command: npm start
+    volumes:
+      - ./data:/usr/src/app/data
+    environment:
+      - NODE_ENV=production
+
+  loki:
+    image: grafana/loki:2.9.1
+    ports:
+      - "3100:3100"
+    command: -config.file=/etc/loki/local-config.yaml
+
+  promtail:
+    image: grafana/promtail:2.9.1
+    volumes:
+      - ./promtail-config.yml:/etc/promtail/config.yml
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - /var/log:/var/log
+    command: -config.file=/etc/promtail/config.yml
+    depends_on:
+      - loki
+
+  grafana:
+    image: grafana/grafana:10.0.3
+    ports:
+      - "3000:3000"
+    depends_on:
+      - loki

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Webhook server to forward AMOCRM leads to Planfix",
   "main": "src/index.js",
   "scripts": {
-    "start": "node src/index.js",
+    "start": "node src/worker.js",
+    "worker": "node src/worker.js",
+    "ingest": "node src/index.js",
     "dev": "nodemon src/index.js",
     "test": "vitest run",
     "test-webhook": "node src/testWebhook.js"

--- a/promtail-config.yml
+++ b/promtail-config.yml
@@ -1,0 +1,18 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: docker
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: docker
+          __path__: /var/lib/docker/containers/*/*.log

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ require("dotenv").config();
 const express = require("express");
 const cors = require("cors");
 const morgan = require("morgan");
-const { addWebhook, processQueue } = require("./queue");
+const { addWebhook } = require("./queue");
 
 // Prevent the process from crashing on unexpected errors
 process.on("unhandledRejection", (reason, promise) => {
@@ -35,7 +35,7 @@ app.get("/", (req, res) => {
 // Webhook endpoint
 app.post(WEBHOOK_PATH, async (req, res) => {
   try {
-    addWebhook(req.body);
+    await addWebhook(req.body);
     res.status(200).json({ success: true });
   } catch (error) {
     console.error("Error queueing webhook:", error);
@@ -57,7 +57,6 @@ if (require.main === module) {
   app.listen(PORT, () => {
     console.log(`Server is running on http://localhost:${PORT}`);
     console.log("Environment:", process.env.NODE_ENV || "development");
-    processQueue().catch((e) => console.error("Startup queue error:", e));
   });
 }
 

--- a/src/queue.js
+++ b/src/queue.js
@@ -100,6 +100,12 @@ function scheduleNext() {
       nextTimer = null;
       processQueue().catch((e) => console.error("Queue processing error:", e));
     }, delay);
+  } else {
+    // console.log('No rows to process, scheduling next check in 5 seconds...');
+    nextTimer = setTimeout(() => {
+      nextTimer = null;
+      processQueue().catch((e) => console.error("Queue processing error:", e));
+    }, 5000);
   }
 }
 

--- a/src/queue.js
+++ b/src/queue.js
@@ -122,6 +122,7 @@ async function handleRow(row) {
     const attempts = row.attempts + 1;
     const sleepTime = DELAY * row.attempts ** 3 * 2;
     const nextAttempt = Date.now() + sleepTime;
+    console.log(`Error processing row ${row.id}:`, err.message.replace(/\n/g, " "));
     console.log(
       `Retrying row ${row.id}: attempts=${attempts - 1}, sleep=${
         sleepTime / 1000

--- a/src/webhookHandler.js
+++ b/src/webhookHandler.js
@@ -249,6 +249,9 @@ async function processWebhook(inputData, queueRow) {
     if (contacts.length === 0) {
       throw new Error(`Lead ${leadId} has no contacts`);
     }
+    if (task?.url) {
+      console.log('result:', task.url);
+    }
     return { body, lead, taskParams, task };
   }
 

--- a/src/webhookHandler.js
+++ b/src/webhookHandler.js
@@ -221,14 +221,6 @@ async function processWebhook(inputData, queueRow) {
     token
   );
 
-  if (contacts.length === 0) {
-    console.error(`Failed to retrieve lead details for lead ID: ${leadId}`);
-    // create task first, then waiting for contacts appears 
-    if (queueRow.attempts > 0) {
-      throw new Error(`Failed to retrieve lead details for lead ID: ${leadId}`);
-    }
-  }
-
   // Prepare task parameters
   const taskParams = extractTaskParams(
     lead,
@@ -241,6 +233,14 @@ async function processWebhook(inputData, queueRow) {
   if (deleted) {
     console.error(`Lead ${leadId} deleted`);
     return { body, lead, taskParams, task: null };
+  }
+
+  if (contacts.length === 0) {
+    console.error(`Failed to retrieve lead details for lead ID: ${leadId}`);
+    // create task first, then waiting for contacts appears 
+    if (queueRow.attempts > 0) {
+      throw new Error(`Failed to retrieve lead details for lead ID: ${leadId}`);
+    }
   }
 
   // Create task in Planfix

--- a/src/worker.js
+++ b/src/worker.js
@@ -1,0 +1,14 @@
+require('./logger');
+require('dotenv').config();
+const { processQueue } = require('./queue');
+
+async function start() {
+  console.log('Worker started');
+  await processQueue();
+}
+
+if (require.main === module) {
+  start().catch((e) => console.error('Worker error:', e));
+}
+
+module.exports = { start };


### PR DESCRIPTION
## Summary
- split queue worker into `src/worker.js`
- expose async `addWebhook` with retries
- remove queue execution from `src/index.js`
- update npm scripts for separate ingest/worker commands
- document new commands and docker-compose usage
- add docker-compose with Grafana/Loki/Promtail

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685677053ac4832cbf5d36f55ce8831c