### PR TITLE
Disable queue processing in ingest

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,10 @@ Run the queue worker and the ingest service separately using `tsx`:
 
 ```bash
 npm start        # start the worker
-npm run ingest   # start the webhook collector
+npm run ingest   # start the webhook collector (queue processing disabled)
+
+The `ingest` script sets `INGEST_ONLY=true` so incoming webhooks are stored but
+not processed. Run the worker separately to handle the queue.
 ```
 
 ## Docker

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "tsc",
     "start": "tsx src/worker.ts",
     "worker": "tsx src/worker.ts",
-    "ingest": "tsx src/index.ts",
+    "ingest": "INGEST_ONLY=true tsx src/index.ts",
     "dev": "nodemon --exec tsx src/index.ts",
     "test": "vitest run",
     "test-webhook": "tsx src/testWebhook.ts"

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -5,6 +5,8 @@ import Database from 'better-sqlite3';
 import { config } from './config.js';
 import type { ProcessWebhook } from './handlers/types.js';
 
+const PROCESSING_ENABLED = process.env.INGEST_ONLY !== 'true';
+
 const DB_DIR = path.join(process.cwd(), 'data');
 const DB_PATH = path.join(DB_DIR, 'webhooks.db');
 
@@ -70,7 +72,9 @@ export async function addWebhook(name: string, body: any, retries = 3, interval 
     try {
       db.prepare('INSERT INTO queue (checksum, webhook, body, created_at, next_attempt) VALUES (?,?,?,?,?)')
         .run(sum, name, JSON.stringify(body), Date.now(), Date.now());
-      scheduleNext();
+      if (PROCESSING_ENABLED) {
+        scheduleNext();
+      }
       return true;
     } catch (err: any) {
       console.error(`Failed to write webhook (attempt ${attempt}):`, err.message);
@@ -87,6 +91,9 @@ export async function addWebhook(name: string, body: any, retries = 3, interval 
 let processing = false;
 
 function scheduleNext() {
+  if (!PROCESSING_ENABLED) {
+    return;
+  }
   if (nextTimer) clearTimeout(nextTimer);
   const row = db
     .prepare('SELECT id, next_attempt FROM queue WHERE attempts < ? ORDER BY next_attempt LIMIT 1')


### PR DESCRIPTION
## Summary
- avoid triggering the worker when running `npm run ingest`
- allow the ingest service to just queue webhooks
- document the new behaviour in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686be5738f78832ca6700456122595da