### PR TITLE
Unify handlers and add startup config checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This service receives webhooks from AMOCRM when new leads are created and forwar
 4. Edit the `.env` file with your configuration:
    ```
    AMOCRM_TOKEN=your_amocrm_access_token
+   # AGENT_TOKEN and CREATE_TASK_URL may be specified here or in config.yml
    AGENT_TOKEN=your_planfix_agent_token
    CREATE_TASK_URL=https://bot-dev.stable.popstas.ru/agent/planfix/tool/planfix_create_task
    PORT=3012
@@ -119,10 +120,12 @@ target:
 | `PORT` | No | Port to run the server on (default: 3012) |
 | `NODE_ENV` | No | Node environment (development/production) |
 | `AMOCRM_TOKEN` | Yes | AMOCRM OAuth access token |
-| `AGENT_TOKEN` | Yes | Planfix agent token |
-| `CREATE_TASK_URL` | No | Planfix task creation endpoint (default: provided URL) |
+| `AGENT_TOKEN` | Yes* | Planfix agent token |
+| `CREATE_TASK_URL` | Yes* | Planfix task creation endpoint |
 | `CONFIG` | No | Path to `config.yml` (default: `data/config.yml`) |
 | `PROXY_URL` | No | Proxy URL for AMOCRM requests |
+
+`*` Required if not provided in `config.yml` under `target`.
 
 ## License
 

--- a/src/handlers/_example.ts
+++ b/src/handlers/_example.ts
@@ -1,0 +1,20 @@
+import { createPlanfixTask } from '../target.js';
+import { getWebhookConfig } from '../config.js';
+import type { ProcessWebhookResult } from './types.js';
+import type { WebhookItem } from '../config.js';
+
+export const webhookName = '_example';
+
+export interface ExampleConfig extends WebhookItem {
+  exampleField?: string;
+}
+
+const webhookConf = getWebhookConfig(webhookName) as ExampleConfig;
+
+export async function processWebhook({ body }: { body: any }): Promise<ProcessWebhookResult> {
+  const taskParams = { example: webhookConf?.exampleField, body };
+  const task = await createPlanfixTask(taskParams);
+  return { body, lead: {}, taskParams, task };
+}
+
+export default { processWebhook };

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,15 @@ import { addWebhook } from './queue.js';
 import { config } from './config.js';
 import { fileURLToPath } from 'url';
 
+function validateTargetConfig() {
+  const url = config.target?.url || process.env.CREATE_TASK_URL;
+  const token = config.target?.token || process.env.AGENT_TOKEN;
+  if (!url || !token) {
+    console.error('Missing target.url or target.token');
+    process.exit(1);
+  }
+}
+
 const app = express();
 const PORT = process.env.PORT || 3012;
 
@@ -40,6 +49,7 @@ app.use((err: any, req: express.Request, res: express.Response, next: express.Ne
 
 const filename = fileURLToPath(import.meta.url);
 if (process.argv[1] === filename) {
+  validateTargetConfig();
   app.listen(Number(PORT), () => {
     console.log(`Server is running on http://localhost:${PORT}`);
     console.log('Environment:', process.env.NODE_ENV || 'development');

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -114,7 +114,11 @@ async function handleRow(row: any) {
   try {
     const data = JSON.parse(row.body);
     const handler = await getHandler(row.webhook);
+    console.log(`processWebhook ${row.webhook}`);
     const response = await handler({ body: data }, row);
+    if (response?.task?.url) {
+      console.log('result:', response.task.url);
+    }
     db.prepare('INSERT INTO processed (checksum, webhook, body, created_at, processed_at, attempts, response) VALUES (?,?,?,?,?,?,?)')
       .run(row.checksum, row.webhook, row.body, row.created_at, Date.now(), row.attempts + 1, JSON.stringify(response));
     db.prepare('DELETE FROM queue WHERE id=?').run(row.id);

--- a/src/target.ts
+++ b/src/target.ts
@@ -1,9 +1,14 @@
 import fetch from 'node-fetch';
+import { config } from './config.js';
 
-export async function createPlanfixTask(taskParams: any, agentToken: string, createTaskUrl: string) {
-  const url = createTaskUrl || "";
+export async function createPlanfixTask(taskParams: any) {
+  const agentToken = config.target?.token || process.env.AGENT_TOKEN;
+  const url = config.target?.url || process.env.CREATE_TASK_URL;
+  if (!agentToken) {
+    throw new Error('AGENT_TOKEN is required');
+  }
   if (!url) {
-    throw new Error("CREATE_TASK_URL is required");
+    throw new Error('CREATE_TASK_URL is required');
   }
 
   const res = await fetch(url, {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,7 +1,17 @@
 import './logger.js';
 import 'dotenv/config';
 import { processQueue } from './queue.js';
+import { config } from './config.js';
 import { fileURLToPath } from 'url';
+
+function validateTargetConfig() {
+  const url = config.target?.url || process.env.CREATE_TASK_URL;
+  const token = config.target?.token || process.env.AGENT_TOKEN;
+  if (!url || !token) {
+    console.error('Missing target.url or target.token');
+    process.exit(1);
+  }
+}
 
 export async function start() {
   console.log('Worker started');
@@ -10,5 +20,6 @@ export async function start() {
 
 const filename = fileURLToPath(import.meta.url);
 if (process.argv[1] === filename) {
+  validateTargetConfig();
   start().catch(e => console.error('Worker error:', e));
 }


### PR DESCRIPTION
## Summary
- add `_example` handler as template
- streamline planfix integration by reading target settings inside `createPlanfixTask`
- add webhook name constants and config types for handlers
- move request/result logging to queue handler
- validate target config on server and worker start
- update docs for new behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686bfbd9303c832c8598f341cb61e58f