### PR TITLE
Support webhook defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,12 +99,17 @@ npm run test-webhook -- <path-to-json>
 ## Configuration
 
 The application reads settings from `config.yml`. Override the location with the `CONFIG` environment variable.
+Each webhook entry may specify optional `tags`, `pipeline`, `project` and `leadSource` values which will be added to created tasks if they are not already set.
 Example:
 
 ```yml
 webhooks:
   - name: amocrm
     webhook_path: /amocrm
+    tags: [sales]
+    pipeline: Sales
+    project: Website
+    leadSource: AMOCRM
 queue:
   max_attempts: 12
   start_delay: 1000

--- a/data/config-example.yml
+++ b/data/config-example.yml
@@ -2,11 +2,21 @@ webhooks:
   - name: amocrm
     token: asd
     webhook_path: /amocrm
+    tags: [sales]
+    pipeline: Sales
+    project: Website
+    leadSource: AMOCRM
   - name: manychat
     leadSource: ManyChat
+    tags: [bot]
+    pipeline: Chat
+    project: Website
     webhook_path: /manychat
   - name: tilda
     leadSource: Tilda
+    tags: [landing]
+    pipeline: Web
+    project: Website
     webhook_path: /tilda
 queue:
   max_attempts: 12

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,15 @@ import fs from 'fs';
 import path from 'path';
 import yaml from 'js-yaml';
 
-export interface WebhookItem { name: string; token?: string; webhook_path: string; }
+export interface WebhookItem {
+  name: string;
+  token?: string;
+  webhook_path: string;
+  tags?: string[];
+  pipeline?: string;
+  project?: string;
+  leadSource?: string;
+}
 export interface QueueConfig { max_attempts?: number; start_delay?: number; }
 export interface TargetConfig { token?: string; url?: string; }
 

--- a/src/handlers/_example.ts
+++ b/src/handlers/_example.ts
@@ -1,5 +1,6 @@
 import { createPlanfixTask } from '../target.js';
 import { getWebhookConfig } from '../config.js';
+import { appendDefaults } from './utils.js';
 import type { ProcessWebhookResult } from './types.js';
 import type { WebhookItem } from '../config.js';
 
@@ -13,6 +14,7 @@ const webhookConf = getWebhookConfig(webhookName) as ExampleConfig;
 
 export async function processWebhook({ headers, body }: { headers: any; body: any }): Promise<ProcessWebhookResult> {
   const taskParams = { example: webhookConf?.exampleField, headers, body };
+  appendDefaults(taskParams, webhookConf);
   const task = await createPlanfixTask(taskParams);
   return { body, lead: {}, taskParams, task };
 }

--- a/src/handlers/amocrm.ts
+++ b/src/handlers/amocrm.ts
@@ -5,6 +5,7 @@ import fs from 'fs';
 import path from 'path';
 import { config, getWebhookConfig } from '../config.js';
 import { createPlanfixTask } from '../target.js';
+import { appendDefaults } from './utils.js';
 import type { WebhookItem } from '../config.js';
 import type { ProcessWebhookResult } from './types.js';
 import { fileURLToPath } from 'url';
@@ -281,6 +282,8 @@ async function processWebhook({ headers, body }, queueRow): Promise<ProcessWebho
   if (pipelineName) {
     taskParams.pipeline = pipelineName;
   }
+
+  appendDefaults(taskParams, webhookConf);
 
   if (deleted) {
     console.error(`Lead ${leadId} deleted`);

--- a/src/handlers/manychat.ts
+++ b/src/handlers/manychat.ts
@@ -1,5 +1,6 @@
 import { getWebhookConfig } from '../config.js';
 import { createPlanfixTask } from '../target.js';
+import { appendDefaults } from './utils.js';
 import type { WebhookItem } from '../config.js';
 import type { ProcessWebhookResult } from './types.js';
 
@@ -51,6 +52,7 @@ export function extractTaskParams(lead: any): any {
 export async function processWebhook({ headers, body }: { headers: any; body: any }): Promise<ProcessWebhookResult> {
   const { lead } = extractLeadDetails(body);
   const taskParams = extractTaskParams(lead);
+  appendDefaults(taskParams, webhookConf);
 
   const task = await createPlanfixTask(taskParams);
 

--- a/src/handlers/tilda.ts
+++ b/src/handlers/tilda.ts
@@ -1,5 +1,6 @@
 import { createPlanfixTask } from '../target.js';
 import { getWebhookConfig } from '../config.js';
+import { appendDefaults } from './utils.js';
 import type { ProcessWebhookResult } from './types.js';
 import type { WebhookItem } from '../config.js';
 
@@ -52,6 +53,7 @@ export async function processWebhook({ headers = {}, body }: { headers: any; bod
     return { body, lead: {}, taskParams: {}, task: {} };
   }
   const taskParams = extractTaskParams(body, headers);
+  appendDefaults(taskParams, webhookConf);
   const task = await createPlanfixTask(taskParams);
   return { body, lead: body, taskParams, task };
 }

--- a/src/handlers/utils.ts
+++ b/src/handlers/utils.ts
@@ -1,0 +1,25 @@
+export interface WebhookDefaults {
+  tags?: string[];
+  pipeline?: string;
+  project?: string;
+  leadSource?: string;
+}
+
+export function appendDefaults(taskParams: any, conf: WebhookDefaults | undefined) {
+  if (!conf) return taskParams;
+  if (conf.tags && taskParams.tags === undefined) {
+    taskParams.tags = conf.tags;
+  }
+  if (conf.pipeline && taskParams.pipeline === undefined) {
+    taskParams.pipeline = conf.pipeline;
+  }
+  if (conf.project && taskParams.project === undefined) {
+    taskParams.project = conf.project;
+  }
+  if (conf.leadSource && taskParams.leadSource === undefined) {
+    taskParams.leadSource = conf.leadSource;
+  }
+  return taskParams;
+}
+
+export default { appendDefaults };

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -6,6 +6,9 @@ webhooks:
     webhook_path: /manychat
   - name: tilda
     leadSource: Tilda
+    tags: [landing]
+    pipeline: Web
+    project: Website
     webhook_path: /tilda
 queue:
   max_attempts: 2

--- a/tests/tilda.test.ts
+++ b/tests/tilda.test.ts
@@ -33,6 +33,13 @@ const expected = {
   }
 };
 
+const expectedWithDefaults = {
+  ...expected,
+  tags: ['landing'],
+  pipeline: 'Web',
+  project: 'Website'
+};
+
 describe('tilda handler', () => {
   it('extracts task params', () => {
     const params = extractTaskParams(body, headers);
@@ -41,7 +48,7 @@ describe('tilda handler', () => {
 
   it('processWebhook returns expected structure', async () => {
     const res = await processWebhook({ headers, body });
-    expect(res.taskParams).toEqual(expected);
+    expect(res.taskParams).toEqual(expectedWithDefaults);
     expect(res.lead).toEqual(body);
     expect(res.body).toEqual(body);
     expect(res.task).toEqual({ url: 'ok' });


### PR DESCRIPTION
## Summary
- allow webhook config to define tags, pipeline, project and leadSource
- share `appendDefaults` helper for applying these values
- include defaults in example config and docs
- test applying defaults in Tilda webhook

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6870ba06f428832c9ff63fda3fc9c4bf