### PR TITLE
Handle capitalized fields in Tilda handler

### DIFF
--- a/tests/tilda.test.ts
+++ b/tests/tilda.test.ts
@@ -54,6 +54,29 @@ describe('tilda handler', () => {
     expect(res.task).toEqual({ url: 'ok' });
   });
 
+  it('handles capitalized field names and telegram field', () => {
+    const capBody = {
+      Name: 'Jane Doe',
+      Email: 'jane.doe@example.com',
+      Phone: '+7 (999) 111-11-11',
+      'Ваш_ник_в_Telegram': 'janedoe',
+      formname: 'Cart',
+    };
+    const params = extractTaskParams(capBody, headers);
+    expect(params).toEqual({
+      leadSource: 'Tilda',
+      name: 'Jane Doe',
+      email: 'jane.doe@example.com',
+      phone: '+7 (999) 111-11-11',
+      telegram: 'janedoe',
+      description: 'Поля:\nreferer: https://example.com/form-page-01\nformname: Cart',
+      fields: {
+        referer: 'https://example.com/form-page-01',
+        formname: 'Cart',
+      },
+    });
+  });
+
   it('uses default name when not provided', () => {
     const noNameBody = { email: 'a@b.com', phone: '123', formname: 'Form' };
     const params = extractTaskParams(noNameBody, headers);


### PR DESCRIPTION
## Summary
- improve tilda webhook handler to detect `name`, `phone`, `email` and `telegram` fields regardless of case
- ignore recognized fields in custom fields
- test extraction with capitalized keys

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874c5ec9da0832ca22b05fc4cf2f4d2