### PR TITLE
Add Telegram integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,13 +1,4 @@
-# AMOCRM Configuration
-AMOCRM_TOKEN=your_amocrm_access_token_here
-
-# Planfix Configuration
-AGENT_TOKEN=your_planfix_agent_token_here
-CREATE_TASK_URL=https://agent.host/agent/planfix/tool/planfix_create_task
-
 # Server Configuration
-WEBHOOK_PATH=/webhook
-WEBHOOK_DELAY=5
-PROXY_URL=
-TELEGRAM_BOT_TOKEN=
-TELEGRAM_CHAT_ID=
+PORT=3012
+NODE_ENV=development
+CONFIG=data/config.yml

--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,5 @@ CREATE_TASK_URL=https://agent.host/agent/planfix/tool/planfix_create_task
 WEBHOOK_PATH=/webhook
 WEBHOOK_DELAY=5
 PROXY_URL=
+TELEGRAM_BOT_TOKEN=
+TELEGRAM_CHAT_ID=

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,3 +2,4 @@
 
 - Use `npm test` to run the vitest suite before committing changes.
 - Ensure the server in `src/index.ts` only starts when the file is executed directly (the file already checks `require.main`).
+- Use environment variables only for `CONFIG`, `PORT` and `NODE_ENV`.

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ webhooks:
 queue:
   max_attempts: 12
   start_delay: 1000
-target:
+planfix_agent:
   token: your_planfix_token
   url: https://planfix.example.com
 ```
@@ -130,7 +130,7 @@ target:
 | `CONFIG` | No | Path to `config.yml` (default: `data/config.yml`) |
 | `PROXY_URL` | No | Proxy URL for AMOCRM requests |
 
-`*` Required if not provided in `config.yml` under `target`.
+`*` Required if not provided in `config.yml` under `planfix_agent`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -21,10 +21,6 @@ This service receives webhooks from AMOCRM when new leads are created and forwar
    ```
 4. Edit the `.env` file with your configuration:
    ```
-   AMOCRM_TOKEN=your_amocrm_access_token
-   # AGENT_TOKEN and CREATE_TASK_URL may be specified here or in config.yml
-   AGENT_TOKEN=your_planfix_agent_token
-   CREATE_TASK_URL=https://bot-dev.stable.popstas.ru/agent/planfix/tool/planfix_create_task
    PORT=3012
    NODE_ENV=development
    CONFIG=data/config.yml
@@ -128,15 +124,7 @@ telegram:
 |----------|----------|-------------|
 | `PORT` | No | Port to run the server on (default: 3012) |
 | `NODE_ENV` | No | Node environment (development/production) |
-| `AMOCRM_TOKEN` | Yes | AMOCRM OAuth access token |
-| `AGENT_TOKEN` | Yes* | Planfix agent token |
-| `CREATE_TASK_URL` | Yes* | Planfix task creation endpoint |
 | `CONFIG` | No | Path to `config.yml` (default: `data/config.yml`) |
-| `PROXY_URL` | No | Proxy URL for AMOCRM requests |
-| `TELEGRAM_BOT_TOKEN` | No | Telegram bot token |
-| `TELEGRAM_CHAT_ID` | No | Chat or channel ID for Telegram messages |
-
-`*` Required if not provided in `config.yml` under `planfix_agent`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ queue:
 planfix_agent:
   token: your_planfix_token
   url: https://planfix.example.com
+telegram:
+  bot_name: example_bot
+  bot_token: token
+  chat_id: 123456
 ```
 
 ## Environment Variables
@@ -129,6 +133,8 @@ planfix_agent:
 | `CREATE_TASK_URL` | Yes* | Planfix task creation endpoint |
 | `CONFIG` | No | Path to `config.yml` (default: `data/config.yml`) |
 | `PROXY_URL` | No | Proxy URL for AMOCRM requests |
+| `TELEGRAM_BOT_TOKEN` | No | Telegram bot token |
+| `TELEGRAM_CHAT_ID` | No | Chat or channel ID for Telegram messages |
 
 `*` Required if not provided in `config.yml` under `planfix_agent`.
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,2 +1,2 @@
 - [ ] change createPlanfixTask(taskParams, agentToken, createTaskUrl) to createPlanfixTask(taskParams)
-- [ ] check config.target url and token on start, fail if not set
+- [ ] check config.planfix_agent url and token on start, fail if not set

--- a/data/config-example.yml
+++ b/data/config-example.yml
@@ -24,4 +24,8 @@ queue:
 planfix_agent:
   token: asd
   url: http://example.com
+telegram:
+  bot_name: example_bot
+  bot_token: token
+  chat_id: 123456
 proxy_url: http://host:port

--- a/data/config-example.yml
+++ b/data/config-example.yml
@@ -21,7 +21,7 @@ webhooks:
 queue:
   max_attempts: 12
   start_delay: 5
-target:
+planfix_agent:
   token: asd
   url: http://example.com
 proxy_url: http://host:port

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,9 +14,9 @@ export interface WebhookItem {
 export interface QueueConfig { max_attempts?: number; start_delay?: number; }
 export interface PlanfixAgentConfig { token?: string; url?: string; }
 export interface TelegramConfig {
-  bot_name?: string;
-  bot_token?: string;
-  chat_id?: string;
+  bot_name: string;
+  bot_token: string;
+  chat_id: string;
 }
 
 export interface Config {

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,7 +13,11 @@ export interface WebhookItem {
 }
 export interface QueueConfig { max_attempts?: number; start_delay?: number; }
 export interface PlanfixAgentConfig { token?: string; url?: string; }
-export interface TelegramConfig { bot_name?: string; bot_token?: string; }
+export interface TelegramConfig {
+  bot_name?: string;
+  bot_token?: string;
+  chat_id?: string;
+}
 
 export interface Config {
   webhooks: WebhookItem[];

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,13 +12,13 @@ export interface WebhookItem {
   leadSource?: string;
 }
 export interface QueueConfig { max_attempts?: number; start_delay?: number; }
-export interface TargetConfig { token?: string; url?: string; }
+export interface PlanfixAgentConfig { token?: string; url?: string; }
 export interface TelegramConfig { bot_name?: string; bot_token?: string; }
 
 export interface Config {
   webhooks: WebhookItem[];
   queue?: QueueConfig;
-  target?: TargetConfig;
+  planfix_agent?: PlanfixAgentConfig;
   telegram?: TelegramConfig;
   proxy_url?: string;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,11 +13,13 @@ export interface WebhookItem {
 }
 export interface QueueConfig { max_attempts?: number; start_delay?: number; }
 export interface TargetConfig { token?: string; url?: string; }
+export interface TelegramConfig { bot_name?: string; bot_token?: string; }
 
 export interface Config {
   webhooks: WebhookItem[];
   queue?: QueueConfig;
   target?: TargetConfig;
+  telegram?: TelegramConfig;
   proxy_url?: string;
 }
 

--- a/src/handlers/_example.ts
+++ b/src/handlers/_example.ts
@@ -15,7 +15,7 @@ const webhookConf = getWebhookConfig(webhookName) as ExampleConfig;
 export async function processWebhook({ headers, body }: { headers: any; body: any }): Promise<ProcessWebhookResult> {
   const taskParams = { example: webhookConf?.exampleField, headers, body };
   appendDefaults(taskParams, webhookConf);
-  const task = await sendToTargets(taskParams);
+  const task = await sendToTargets(taskParams, webhookName);
   return { body, lead: {}, taskParams, task };
 }
 

--- a/src/handlers/_example.ts
+++ b/src/handlers/_example.ts
@@ -1,4 +1,4 @@
-import { createPlanfixTask } from '../target.js';
+import { sendToTargets } from '../target.js';
 import { getWebhookConfig } from '../config.js';
 import { appendDefaults } from './utils.js';
 import type { ProcessWebhookResult } from './types.js';
@@ -15,7 +15,7 @@ const webhookConf = getWebhookConfig(webhookName) as ExampleConfig;
 export async function processWebhook({ headers, body }: { headers: any; body: any }): Promise<ProcessWebhookResult> {
   const taskParams = { example: webhookConf?.exampleField, headers, body };
   appendDefaults(taskParams, webhookConf);
-  const task = await createPlanfixTask(taskParams);
+  const task = await sendToTargets(taskParams);
   return { body, lead: {}, taskParams, task };
 }
 

--- a/src/handlers/amocrm.ts
+++ b/src/handlers/amocrm.ts
@@ -300,7 +300,7 @@ async function processWebhook({ headers, body }, queueRow): Promise<ProcessWebho
 
 
   // Create task in Planfix
-  const task = await sendToTargets(taskParams);
+  const task = await sendToTargets(taskParams, webhookName);
   if (contacts.length === 0) {
     throw new Error(`Lead ${leadId} has no contacts`);
   }

--- a/src/handlers/amocrm.ts
+++ b/src/handlers/amocrm.ts
@@ -4,7 +4,7 @@ import { ProxyAgent } from 'proxy-agent';
 import fs from 'fs';
 import path from 'path';
 import { config, getWebhookConfig } from '../config.js';
-import { createPlanfixTask } from '../target.js';
+import { sendToTargets } from '../target.js';
 import { appendDefaults } from './utils.js';
 import type { WebhookItem } from '../config.js';
 import type { ProcessWebhookResult } from './types.js';
@@ -303,7 +303,7 @@ async function processWebhook({ headers, body }, queueRow): Promise<ProcessWebho
   }
 
   // Create task in Planfix
-  const task = await createPlanfixTask(taskParams);
+  const task = await sendToTargets(taskParams);
   if (contacts.length === 0) {
     throw new Error(`Lead ${leadId} has no contacts`);
   }

--- a/src/handlers/amocrm.ts
+++ b/src/handlers/amocrm.ts
@@ -27,7 +27,7 @@ async function amoGet(baseUrl, path, token) {
       "Content-Type": "application/json",
     },
   };
-  const proxy = process.env.PROXY_URL || config.proxy_url;
+  const proxy = config.proxy_url;
   if (proxy) {
     options.agent = new ProxyAgent(proxy);
   }
@@ -232,8 +232,8 @@ function delay(ms) {
 }
 
 async function processWebhook({ headers, body }, queueRow): Promise<ProcessWebhookResult> {
-  const token = webhookConf?.token || process.env.AMOCRM_TOKEN;
-  const webhookDelay = (config.queue?.start_delay ?? parseInt(process.env.WEBHOOK_DELAY || '5', 10)) * 1000;
+  const token = webhookConf?.token;
+  const webhookDelay = (config.queue?.start_delay ?? 5) * 1000;
 
   if (!token) throw new Error("AMOCRM access token is required");
 
@@ -298,9 +298,6 @@ async function processWebhook({ headers, body }, queueRow): Promise<ProcessWebho
     }
   }
 
-  if (process.env.MANAGER_EMAIL) {
-    taskParams.managerEmail = process.env.MANAGER_EMAIL;
-  }
 
   // Create task in Planfix
   const task = await sendToTargets(taskParams);

--- a/src/handlers/manychat.ts
+++ b/src/handlers/manychat.ts
@@ -1,5 +1,5 @@
 import { getWebhookConfig } from '../config.js';
-import { createPlanfixTask } from '../target.js';
+import { sendToTargets } from '../target.js';
 import { appendDefaults } from './utils.js';
 import type { WebhookItem } from '../config.js';
 import type { ProcessWebhookResult } from './types.js';
@@ -54,7 +54,7 @@ export async function processWebhook({ headers, body }: { headers: any; body: an
   const taskParams = extractTaskParams(lead);
   appendDefaults(taskParams, webhookConf);
 
-  const task = await createPlanfixTask(taskParams);
+  const task = await sendToTargets(taskParams);
 
   return { body, lead, taskParams, task };
 }

--- a/src/handlers/manychat.ts
+++ b/src/handlers/manychat.ts
@@ -54,7 +54,7 @@ export async function processWebhook({ headers, body }: { headers: any; body: an
   const taskParams = extractTaskParams(lead);
   appendDefaults(taskParams, webhookConf);
 
-  const task = await sendToTargets(taskParams);
+  const task = await sendToTargets(taskParams, webhookName);
 
   return { body, lead, taskParams, task };
 }

--- a/src/handlers/tilda.ts
+++ b/src/handlers/tilda.ts
@@ -1,4 +1,4 @@
-import { createPlanfixTask } from '../target.js';
+import { sendToTargets } from '../target.js';
 import { getWebhookConfig } from '../config.js';
 import { appendDefaults } from './utils.js';
 import type { ProcessWebhookResult } from './types.js';
@@ -102,7 +102,7 @@ export async function processWebhook({ headers = {}, body }: { headers: any; bod
   }
   const taskParams = extractTaskParams(body, headers);
   appendDefaults(taskParams, webhookConf);
-  const task = await createPlanfixTask(taskParams);
+  const task = await sendToTargets(taskParams);
   return { body, lead: body, taskParams, task };
 }
 

--- a/src/handlers/tilda.ts
+++ b/src/handlers/tilda.ts
@@ -55,8 +55,23 @@ export function extractTaskParams(body: any, headers: any): any {
   const lines: string[] = [];
 
   if (headers?.referer) {
-    fields.referer = headers.referer;
-    lines.push(`referer: ${headers.referer}`);
+    try {
+      const url = new URL(headers.referer);
+      const params = url.searchParams;
+      const utmSource = params.get('utm_source');
+      const utmMedium = params.get('utm_medium');
+      const utmCampaign = params.get('utm_campaign');
+      if (utmSource) fields.utm_source = utmSource;
+      if (utmMedium) fields.utm_medium = utmMedium;
+      if (utmCampaign) fields.utm_campaign = utmCampaign;
+      params.delete('mcp_token');
+      const search = params.toString();
+      url.search = search ? `?${search}` : '';
+      fields.referer = url.toString();
+    } catch {
+      fields.referer = headers.referer;
+    }
+    lines.push(`referer: ${fields.referer}`);
   }
 
   const ignored = new Set([
@@ -102,7 +117,7 @@ export async function processWebhook({ headers = {}, body }: { headers: any; bod
   }
   const taskParams = extractTaskParams(body, headers);
   appendDefaults(taskParams, webhookConf);
-  const task = await sendToTargets(taskParams);
+  const task = await sendToTargets(taskParams, webhookName);
   return { body, lead: body, taskParams, task };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,10 +8,10 @@ import { config } from './config.js';
 import { fileURLToPath } from 'url';
 
 function validateTargetConfig() {
-  const url = config.target?.url || process.env.CREATE_TASK_URL;
-  const token = config.target?.token || process.env.AGENT_TOKEN;
+  const url = config.planfix_agent?.url || process.env.CREATE_TASK_URL;
+  const token = config.planfix_agent?.token || process.env.AGENT_TOKEN;
   if (!url || !token) {
-    console.error('Missing target.url or target.token');
+    console.error('Missing planfix_agent.url or planfix_agent.token');
     process.exit(1);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,8 +8,8 @@ import { config } from './config.js';
 import { fileURLToPath } from 'url';
 
 function validateTargetConfig() {
-  const url = config.planfix_agent?.url || process.env.CREATE_TASK_URL;
-  const token = config.planfix_agent?.token || process.env.AGENT_TOKEN;
+  const url = config.planfix_agent?.url;
+  const token = config.planfix_agent?.token;
   if (!url || !token) {
     console.error('Missing planfix_agent.url or planfix_agent.token');
     process.exit(1);

--- a/src/target.ts
+++ b/src/target.ts
@@ -2,13 +2,13 @@ import fetch from 'node-fetch';
 import { config } from './config.js';
 
 export async function createPlanfixTask(taskParams: any) {
-  const agentToken = config.planfix_agent?.token || process.env.AGENT_TOKEN;
-  const url = config.planfix_agent?.url || process.env.CREATE_TASK_URL;
+  const agentToken = config.planfix_agent?.token;
+  const url = config.planfix_agent?.url;
   if (!agentToken) {
-    throw new Error('AGENT_TOKEN is required');
+    throw new Error('planfix_agent.token is required');
   }
   if (!url) {
-    throw new Error('CREATE_TASK_URL is required');
+    throw new Error('planfix_agent.url is required');
   }
 
   const res = await fetch(url, {
@@ -30,12 +30,8 @@ export async function createPlanfixTask(taskParams: any) {
 }
 
 export async function sendTelegramMessage(taskParams: any) {
-  const botToken = config.telegram?.bot_token || process.env.TELEGRAM_BOT_TOKEN;
-  const chatId =
-    config.telegram?.chat_id ||
-    config.telegram?.bot_name ||
-    process.env.TELEGRAM_CHAT_ID ||
-    process.env.TELEGRAM_BOT_NAME;
+  if (!config.telegram) return null;
+  const { bot_token: botToken, chat_id: chatId } = config.telegram;
   if (!botToken || !chatId) return null;
 
   let text = taskParams.description || '';

--- a/src/target.ts
+++ b/src/target.ts
@@ -29,7 +29,7 @@ export async function createPlanfixTask(taskParams: any) {
   return res.json();
 }
 
-export async function sendTelegramMessage(taskParams: any) {
+export async function sendTelegramMessage(taskParams: any, webhookName = '') {
   if (!config.telegram) return null;
   const { bot_token: botToken, chat_id: chatId } = config.telegram;
   if (!botToken || !chatId) return null;
@@ -37,6 +37,10 @@ export async function sendTelegramMessage(taskParams: any) {
   let text = taskParams.description || '';
   if (!text) {
     text = JSON.stringify(taskParams);
+  }
+
+  if (webhookName) {
+    text = `${webhookName}:\n\n${text}`;
   }
 
   if (Array.isArray(taskParams.tags) && taskParams.tags.length) {
@@ -58,10 +62,10 @@ export async function sendTelegramMessage(taskParams: any) {
   return res.json();
 }
 
-export async function sendToTargets(taskParams: any) {
+export async function sendToTargets(taskParams: any, webhookName = '') {
   const task = await createPlanfixTask(taskParams);
   try {
-    await sendTelegramMessage(taskParams);
+    await sendTelegramMessage(taskParams, webhookName);
   } catch (e: any) {
     console.error('Failed to send telegram message:', e.message);
   }

--- a/src/target.ts
+++ b/src/target.ts
@@ -31,8 +31,12 @@ export async function createPlanfixTask(taskParams: any) {
 
 export async function sendTelegramMessage(taskParams: any) {
   const botToken = config.telegram?.bot_token || process.env.TELEGRAM_BOT_TOKEN;
-  const botName = config.telegram?.bot_name || process.env.TELEGRAM_BOT_NAME;
-  if (!botToken || !botName) return null;
+  const chatId =
+    config.telegram?.chat_id ||
+    config.telegram?.bot_name ||
+    process.env.TELEGRAM_CHAT_ID ||
+    process.env.TELEGRAM_BOT_NAME;
+  if (!botToken || !chatId) return null;
 
   let text = taskParams.description || '';
   if (!text) {
@@ -48,7 +52,7 @@ export async function sendTelegramMessage(taskParams: any) {
   const res = await fetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ chat_id: botName, text }),
+    body: JSON.stringify({ chat_id: chatId, text }),
   });
 
   if (!res.ok) {

--- a/src/target.ts
+++ b/src/target.ts
@@ -29,7 +29,11 @@ export async function createPlanfixTask(taskParams: any) {
   return res.json();
 }
 
-export async function sendTelegramMessage(taskParams: any, webhookName = '') {
+export async function sendTelegramMessage(
+  taskParams: any,
+  webhookName = '',
+  task: any = null
+) {
   if (!config.telegram) return null;
   const { bot_token: botToken, chat_id: chatId } = config.telegram;
   if (!botToken || !chatId) return null;
@@ -39,8 +43,21 @@ export async function sendTelegramMessage(taskParams: any, webhookName = '') {
     text = JSON.stringify(taskParams);
   }
 
+  const details: string[] = [];
+  if (taskParams.name) details.push(`name: ${taskParams.name}`);
+  if (taskParams.pipeline) details.push(`pipeline: ${taskParams.pipeline}`);
+  if (taskParams.leadSource)
+    details.push(`leadSource: ${taskParams.leadSource}`);
+  if (details.length) {
+    text += (text ? '\n' : '') + details.join('\n');
+  }
+
   if (webhookName) {
     text = `${webhookName}:\n\n${text}`;
+  }
+
+  if (task?.url) {
+    text += (text ? '\n' : '') + task.url;
   }
 
   if (Array.isArray(taskParams.tags) && taskParams.tags.length) {
@@ -65,7 +82,7 @@ export async function sendTelegramMessage(taskParams: any, webhookName = '') {
 export async function sendToTargets(taskParams: any, webhookName = '') {
   const task = await createPlanfixTask(taskParams);
   try {
-    await sendTelegramMessage(taskParams, webhookName);
+    await sendTelegramMessage(taskParams, webhookName, task);
   } catch (e: any) {
     console.error('Failed to send telegram message:', e.message);
   }

--- a/src/target.ts
+++ b/src/target.ts
@@ -2,8 +2,8 @@ import fetch from 'node-fetch';
 import { config } from './config.js';
 
 export async function createPlanfixTask(taskParams: any) {
-  const agentToken = config.target?.token || process.env.AGENT_TOKEN;
-  const url = config.target?.url || process.env.CREATE_TASK_URL;
+  const agentToken = config.planfix_agent?.token || process.env.AGENT_TOKEN;
+  const url = config.planfix_agent?.url || process.env.CREATE_TASK_URL;
   if (!agentToken) {
     throw new Error('AGENT_TOKEN is required');
   }

--- a/src/target.ts
+++ b/src/target.ts
@@ -38,18 +38,22 @@ export async function sendTelegramMessage(
   const { bot_token: botToken, chat_id: chatId } = config.telegram;
   if (!botToken || !chatId) return null;
 
-  let text = taskParams.description || '';
+  let text = (taskParams.description || '').trim();
   if (!text) {
     text = JSON.stringify(taskParams);
   }
 
   const details: string[] = [];
-  if (taskParams.name) details.push(`name: ${taskParams.name}`);
-  if (taskParams.pipeline) details.push(`pipeline: ${taskParams.pipeline}`);
+  if (taskParams.name) details.push(`Имя: ${taskParams.name}`);
+  if (taskParams.phone) details.push(`Телефон: ${taskParams.phone}`);
+  if (taskParams.email) details.push(`Email: ${taskParams.email}`);
+  if (taskParams.telegram) details.push(`Telegram: ${taskParams.telegram}`);
+  if (taskParams.instagram) details.push(`Instagram: https://instagram.com/${taskParams.instagram}`);
+  if (taskParams.pipeline) details.push(`Воронка: ${taskParams.pipeline}`);
   if (taskParams.leadSource)
-    details.push(`leadSource: ${taskParams.leadSource}`);
+    details.push(`Источник продажи: ${taskParams.leadSource}`);
   if (details.length) {
-    text += (text ? '\n' : '') + details.join('\n');
+    text = `${details.join('\n')}\n\n${text}`;
   }
 
   if (webhookName) {
@@ -57,12 +61,12 @@ export async function sendTelegramMessage(
   }
 
   if (task?.url) {
-    text += (text ? '\n' : '') + task.url;
+    text = `${text}\n\nПланфикс:\n${task.url}`;
   }
 
   if (Array.isArray(taskParams.tags) && taskParams.tags.length) {
     const tags = taskParams.tags.map((t: string) => `#${t}`).join(' ');
-    text += (text ? '\n\n' : '') + tags;
+    text = `${text}\n\n${tags}`;
   }
 
   const url = `https://api.telegram.org/bot${botToken}/sendMessage`;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -5,10 +5,10 @@ import { config } from './config.js';
 import { fileURLToPath } from 'url';
 
 function validateTargetConfig() {
-  const url = config.target?.url || process.env.CREATE_TASK_URL;
-  const token = config.target?.token || process.env.AGENT_TOKEN;
+  const url = config.planfix_agent?.url || process.env.CREATE_TASK_URL;
+  const token = config.planfix_agent?.token || process.env.AGENT_TOKEN;
   if (!url || !token) {
-    console.error('Missing target.url or target.token');
+    console.error('Missing planfix_agent.url or planfix_agent.token');
     process.exit(1);
   }
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -5,8 +5,8 @@ import { config } from './config.js';
 import { fileURLToPath } from 'url';
 
 function validateTargetConfig() {
-  const url = config.planfix_agent?.url || process.env.CREATE_TASK_URL;
-  const token = config.planfix_agent?.token || process.env.AGENT_TOKEN;
+  const url = config.planfix_agent?.url;
+  const token = config.planfix_agent?.token;
   if (!url || !token) {
     console.error('Missing planfix_agent.url or planfix_agent.token');
     process.exit(1);

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -9,8 +9,8 @@ describe('config loader', () => {
   });
 
   it('loads telegram config', () => {
-    expect(config.telegram?.bot_name).toBe('example_bot');
-    expect(config.telegram?.chat_id).toBe('example_chat');
+    expect(config.telegram.bot_name).toBe('example_bot');
+    expect(config.telegram.chat_id).toBe('example_chat');
   });
 
   it('loads planfix agent config', () => {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -11,4 +11,8 @@ describe('config loader', () => {
   it('loads telegram config', () => {
     expect(config.telegram?.bot_name).toBe('example_bot');
   });
+
+  it('loads planfix agent config', () => {
+    expect(config.planfix_agent?.url).toBe('http://example.com');
+  });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -10,6 +10,7 @@ describe('config loader', () => {
 
   it('loads telegram config', () => {
     expect(config.telegram?.bot_name).toBe('example_bot');
+    expect(config.telegram?.chat_id).toBe('example_chat');
   });
 
   it('loads planfix agent config', () => {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -7,4 +7,8 @@ describe('config loader', () => {
   it('loads config with webhook name', () => {
     expect(config.webhooks[0].name).toBe('amocrm');
   });
+
+  it('loads telegram config', () => {
+    expect(config.telegram?.bot_name).toBe('example_bot');
+  });
 });

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -16,3 +16,6 @@ queue:
 target:
   token: t
   url: http://example.com
+telegram:
+  bot_name: example_bot
+  bot_token: token

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -13,7 +13,7 @@ webhooks:
 queue:
   max_attempts: 2
   start_delay: 1000
-target:
+planfix_agent:
   token: t
   url: http://example.com
 telegram:

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -19,3 +19,4 @@ planfix_agent:
 telegram:
   bot_name: example_bot
   bot_token: token
+  chat_id: example_chat

--- a/tests/manychat.test.ts
+++ b/tests/manychat.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 
 vi.mock('../src/target.ts', () => ({
-  createPlanfixTask: vi.fn(async () => ({ url: 'ok' }))
+  sendToTargets: vi.fn(async () => ({ url: 'ok' }))
 }));
 
 import { processWebhook, extractTaskParams } from '../src/handlers/manychat.ts';

--- a/tests/tilda.test.ts
+++ b/tests/tilda.test.ts
@@ -83,6 +83,21 @@ describe('tilda handler', () => {
     expect(params.name).toBe('Unknown name');
   });
 
+  it('parses utm params and strips mcp_token', () => {
+    const hdrs = {
+      referer:
+        'https://example.com/page?utm_source=src&utm_medium=med&utm_campaign=camp&mcp_token=abc&foo=bar',
+    };
+    const params = extractTaskParams({}, hdrs);
+    expect(params.fields).toEqual({
+      referer:
+        'https://example.com/page?utm_source=src&utm_medium=med&utm_campaign=camp&foo=bar',
+      utm_source: 'src',
+      utm_medium: 'med',
+      utm_campaign: 'camp',
+    });
+  });
+
   it('handle test webhook', async () => {
     const res = await processWebhook({ headers, body: { test: 'test' } });
     expect(res.taskParams).toEqual({});

--- a/tests/tilda.test.ts
+++ b/tests/tilda.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 
 vi.mock('../src/target.ts', () => ({
-  createPlanfixTask: vi.fn(async () => ({ url: 'ok' }))
+  sendToTargets: vi.fn(async () => ({ url: 'ok' }))
 }));
 
 import { processWebhook, extractTaskParams } from '../src/handlers/tilda.ts';


### PR DESCRIPTION
## Summary
- extend config with `telegram` section
- add `sendTelegramMessage` and `sendToTargets` helpers
- call `sendToTargets` from handlers
- cover new behavior in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687635f71d20832c9d53d8d3ca53e161