### PR TITLE
Support projectTags in AmoCRM handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ npm run test-webhook -- <path-to-json>
 
 The application reads settings from `config.yml`. Override the location with the `CONFIG` environment variable.
 Each webhook entry may specify optional `tags`, `pipeline`, `project` and `leadSource` values which will be added to created tasks if they are not already set.
-For the `amocrm` webhook you can additionally define `projectTags` and `projectPipelines` to map specific tags or pipeline names to Planfix projects.
+For the `amocrm` webhook you can additionally define `projectTags` and `projectPipelines` to map specific tags or pipeline names to Planfix projects. Matching is case‑insensitive and treats similar‑looking Latin and Cyrillic letters as the same.
 Example:
 
 ```yml

--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ npm run test-webhook -- <path-to-json>
 ## Configuration
 
 The application reads settings from `config.yml`. Override the location with the `CONFIG` environment variable.
-Each webhook entry may specify optional `tags`, `pipeline`, `project`, `leadSource` and `projectTags` values which will be added to created tasks if they are not already set.
+Each webhook entry may specify optional `tags`, `pipeline`, `project` and `leadSource` values which will be added to created tasks if they are not already set.
+For the `amocrm` webhook you can additionally define `projectTags` and `projectPipelines` to map specific tags or pipeline names to Planfix projects.
 Example:
 
 ```yml
@@ -109,6 +110,9 @@ webhooks:
     projectTags:
       tag1: project1
       other_project: other project
+    projectPipelines:
+      Sales: Website Sales
+      Support: Support Project
 queue:
   max_attempts: 12
   start_delay: 1000

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ npm run test-webhook -- <path-to-json>
 ## Configuration
 
 The application reads settings from `config.yml`. Override the location with the `CONFIG` environment variable.
-Each webhook entry may specify optional `tags`, `pipeline`, `project` and `leadSource` values which will be added to created tasks if they are not already set.
+Each webhook entry may specify optional `tags`, `pipeline`, `project`, `leadSource` and `projectTags` values which will be added to created tasks if they are not already set.
 Example:
 
 ```yml
@@ -106,6 +106,9 @@ webhooks:
     pipeline: Sales
     project: Website
     leadSource: AMOCRM
+    projectTags:
+      tag1: project1
+      other_project: other project
 queue:
   max_attempts: 12
   start_delay: 1000

--- a/data/config-example.yml
+++ b/data/config-example.yml
@@ -12,6 +12,7 @@ webhooks:
     projectPipelines:
       Sales: Website Sales
       Support: Support Project
+      1000x: 1000x
   - name: manychat
     leadSource: ManyChat
     tags: [bot]

--- a/data/config-example.yml
+++ b/data/config-example.yml
@@ -6,6 +6,9 @@ webhooks:
     pipeline: Sales
     project: Website
     leadSource: AMOCRM
+    projectTags:
+      tag1: project1
+      other_project: other project
   - name: manychat
     leadSource: ManyChat
     tags: [bot]

--- a/data/config-example.yml
+++ b/data/config-example.yml
@@ -9,6 +9,9 @@ webhooks:
     projectTags:
       tag1: project1
       other_project: other project
+    projectPipelines:
+      Sales: Website Sales
+      Support: Support Project
   - name: manychat
     leadSource: ManyChat
     tags: [bot]

--- a/src/handlers/amocrm.ts
+++ b/src/handlers/amocrm.ts
@@ -15,6 +15,7 @@ export const webhookName = 'amocrm';
 export interface AmocrmConfig extends WebhookItem {
   token?: string;
   projectTags?: Record<string, string>;
+  projectPipelines?: Record<string, string>;
 }
 
 const webhookConf = getWebhookConfig(webhookName) as AmocrmConfig;
@@ -243,6 +244,13 @@ export function applyProjectTags(taskParams, projectTags) {
   return taskParams;
 }
 
+export function applyProjectPipelines(taskParams, projectPipelines) {
+  if (!projectPipelines || !taskParams.pipeline) return taskParams;
+  const mapped = projectPipelines[taskParams.pipeline];
+  if (mapped) taskParams.project = mapped;
+  return taskParams;
+}
+
 async function processWebhook({ headers, body }, queueRow): Promise<ProcessWebhookResult> {
   const token = webhookConf?.token;
   const webhookDelay = (config.queue?.start_delay ?? 5) * 1000;
@@ -297,6 +305,7 @@ async function processWebhook({ headers, body }, queueRow): Promise<ProcessWebho
 
   appendDefaults(taskParams, webhookConf);
   applyProjectTags(taskParams, webhookConf?.projectTags);
+  applyProjectPipelines(taskParams, webhookConf?.projectPipelines);
 
   if (deleted) {
     console.error(`Lead ${leadId} deleted`);

--- a/src/handlers/amocrm.ts
+++ b/src/handlers/amocrm.ts
@@ -233,13 +233,35 @@ function delay(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+function normalizeKey(value: string): string {
+  const cyrMap: Record<string, string> = {
+    'а': 'a',
+    'е': 'e',
+    'ё': 'e',
+    'о': 'o',
+    'р': 'p',
+    'с': 'c',
+    'х': 'x',
+    'у': 'y',
+    'к': 'k',
+    'т': 't',
+    'в': 'b',
+    'м': 'm',
+    'н': 'h',
+  };
+  return value
+    .toLowerCase()
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[аёеорсхуктвмн]/g, ch => cyrMap[ch] || ch);
+}
+
 export function applyProjectTags(taskParams, projectTags) {
   if (!projectTags || !Array.isArray(taskParams.tags)) return taskParams;
   const map = Object.fromEntries(
-    Object.entries(projectTags).map(([k, v]) => [k.toLowerCase(), v])
+    Object.entries(projectTags).map(([k, v]) => [normalizeKey(k), v])
   );
   for (const tag of taskParams.tags) {
-    const mapped = map[tag.toLowerCase()];
+    const mapped = map[normalizeKey(tag)];
     if (mapped) {
       taskParams.project = mapped;
       break;
@@ -251,9 +273,9 @@ export function applyProjectTags(taskParams, projectTags) {
 export function applyProjectPipelines(taskParams, projectPipelines) {
   if (!projectPipelines || !taskParams.pipeline) return taskParams;
   const map = Object.fromEntries(
-    Object.entries(projectPipelines).map(([k, v]) => [k.toLowerCase(), v])
+    Object.entries(projectPipelines).map(([k, v]) => [normalizeKey(k), v])
   );
-  const mapped = map[taskParams.pipeline.toLowerCase()];
+  const mapped = map[normalizeKey(taskParams.pipeline)];
   if (mapped) taskParams.project = mapped;
   return taskParams;
 }

--- a/src/handlers/amocrm.ts
+++ b/src/handlers/amocrm.ts
@@ -235,9 +235,13 @@ function delay(ms) {
 
 export function applyProjectTags(taskParams, projectTags) {
   if (!projectTags || !Array.isArray(taskParams.tags)) return taskParams;
+  const map = Object.fromEntries(
+    Object.entries(projectTags).map(([k, v]) => [k.toLowerCase(), v])
+  );
   for (const tag of taskParams.tags) {
-    if (projectTags[tag]) {
-      taskParams.project = projectTags[tag];
+    const mapped = map[tag.toLowerCase()];
+    if (mapped) {
+      taskParams.project = mapped;
       break;
     }
   }
@@ -246,7 +250,10 @@ export function applyProjectTags(taskParams, projectTags) {
 
 export function applyProjectPipelines(taskParams, projectPipelines) {
   if (!projectPipelines || !taskParams.pipeline) return taskParams;
-  const mapped = projectPipelines[taskParams.pipeline];
+  const map = Object.fromEntries(
+    Object.entries(projectPipelines).map(([k, v]) => [k.toLowerCase(), v])
+  );
+  const mapped = map[taskParams.pipeline.toLowerCase()];
   if (mapped) taskParams.project = mapped;
   return taskParams;
 }

--- a/tests/amocrm.test.ts
+++ b/tests/amocrm.test.ts
@@ -9,6 +9,13 @@ describe('applyProjectTags', () => {
     expect(params.project).toBe('Project X');
   });
 
+  it('matches tag names case-insensitively', () => {
+    const params: any = { tags: ['TAGx'] };
+    const projectTags = { tagx: 'Project X' };
+    applyProjectTags(params, projectTags);
+    expect(params.project).toBe('Project X');
+  });
+
   it('leaves project unchanged when no tag matches', () => {
     const params: any = { tags: ['none'], project: 'Keep' };
     const projectTags = { tagX: 'Project X' };
@@ -20,6 +27,13 @@ describe('applyProjectTags', () => {
 describe('applyProjectPipelines', () => {
   it('overrides project based on pipeline', () => {
     const params: any = { pipeline: 'Sales', project: 'Old' };
+    const map = { Sales: 'SalesProj' };
+    applyProjectPipelines(params, map);
+    expect(params.project).toBe('SalesProj');
+  });
+
+  it('matches pipeline names case-insensitively', () => {
+    const params: any = { pipeline: 'sales', project: 'Old' };
     const map = { Sales: 'SalesProj' };
     applyProjectPipelines(params, map);
     expect(params.project).toBe('SalesProj');

--- a/tests/amocrm.test.ts
+++ b/tests/amocrm.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { applyProjectTags } from '../src/handlers/amocrm.ts';
+
+describe('applyProjectTags', () => {
+  it('sets project based on tag mapping', () => {
+    const params: any = { tags: ['tagX', 'other'] };
+    const projectTags = { tagX: 'Project X' };
+    applyProjectTags(params, projectTags);
+    expect(params.project).toBe('Project X');
+  });
+
+  it('leaves project unchanged when no tag matches', () => {
+    const params: any = { tags: ['none'], project: 'Keep' };
+    const projectTags = { tagX: 'Project X' };
+    applyProjectTags(params, projectTags);
+    expect(params.project).toBe('Keep');
+  });
+});

--- a/tests/amocrm.test.ts
+++ b/tests/amocrm.test.ts
@@ -16,6 +16,13 @@ describe('applyProjectTags', () => {
     expect(params.project).toBe('Project X');
   });
 
+  it('handles mixed case for config key and tag value', () => {
+    const params: any = { tags: ['taG1'] };
+    const projectTags = { TAG1: 'Project 1' };
+    applyProjectTags(params, projectTags);
+    expect(params.project).toBe('Project 1');
+  });
+
   it('leaves project unchanged when no tag matches', () => {
     const params: any = { tags: ['none'], project: 'Keep' };
     const projectTags = { tagX: 'Project X' };
@@ -37,6 +44,13 @@ describe('applyProjectPipelines', () => {
     const map = { Sales: 'SalesProj' };
     applyProjectPipelines(params, map);
     expect(params.project).toBe('SalesProj');
+  });
+
+  it('handles mixed case for config key and pipeline value', () => {
+    const params: any = { pipeline: 'piPeliNe', project: 'Old' };
+    const map = { PipeLine: 'MappedProj' };
+    applyProjectPipelines(params, map);
+    expect(params.project).toBe('MappedProj');
   });
 
   it('ignores when pipeline not mapped', () => {

--- a/tests/amocrm.test.ts
+++ b/tests/amocrm.test.ts
@@ -23,6 +23,13 @@ describe('applyProjectTags', () => {
     expect(params.project).toBe('Project 1');
   });
 
+  it('matches cyrillic look-alike letters in tags', () => {
+    const params: any = { tags: ['tagХ'] };
+    const projectTags = { tagx: 'Project X' };
+    applyProjectTags(params, projectTags);
+    expect(params.project).toBe('Project X');
+  });
+
   it('leaves project unchanged when no tag matches', () => {
     const params: any = { tags: ['none'], project: 'Keep' };
     const projectTags = { tagX: 'Project X' };
@@ -51,6 +58,13 @@ describe('applyProjectPipelines', () => {
     const map = { PipeLine: 'MappedProj' };
     applyProjectPipelines(params, map);
     expect(params.project).toBe('MappedProj');
+  });
+
+  it('matches cyrillic look-alike letters in pipeline name', () => {
+    const params: any = { pipeline: '1000Х', project: 'Old' };
+    const map = { '1000x': '1000x' };
+    applyProjectPipelines(params, map);
+    expect(params.project).toBe('1000x');
   });
 
   it('ignores when pipeline not mapped', () => {

--- a/tests/amocrm.test.ts
+++ b/tests/amocrm.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { applyProjectTags } from '../src/handlers/amocrm.ts';
+import { applyProjectTags, applyProjectPipelines } from '../src/handlers/amocrm.ts';
 
 describe('applyProjectTags', () => {
   it('sets project based on tag mapping', () => {
@@ -14,5 +14,21 @@ describe('applyProjectTags', () => {
     const projectTags = { tagX: 'Project X' };
     applyProjectTags(params, projectTags);
     expect(params.project).toBe('Keep');
+  });
+});
+
+describe('applyProjectPipelines', () => {
+  it('overrides project based on pipeline', () => {
+    const params: any = { pipeline: 'Sales', project: 'Old' };
+    const map = { Sales: 'SalesProj' };
+    applyProjectPipelines(params, map);
+    expect(params.project).toBe('SalesProj');
+  });
+
+  it('ignores when pipeline not mapped', () => {
+    const params: any = { pipeline: 'Other', project: 'Old' };
+    const map = { Sales: 'SalesProj' };
+    applyProjectPipelines(params, map);
+    expect(params.project).toBe('Old');
   });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -21,4 +21,9 @@ describe('config loader', () => {
     const amo = config.webhooks[0] as any;
     expect(amo.projectTags.tagX).toBe('Project X');
   });
+
+  it('loads projectPipelines config', () => {
+    const amo = config.webhooks[0] as any;
+    expect(amo.projectPipelines.Sales).toBe('SalesProj');
+  });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -16,4 +16,9 @@ describe('config loader', () => {
   it('loads planfix agent config', () => {
     expect(config.planfix_agent?.url).toBe('http://example.com');
   });
+
+  it('loads projectTags config', () => {
+    const amo = config.webhooks[0] as any;
+    expect(amo.projectTags.tagX).toBe('Project X');
+  });
 });

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -1,6 +1,8 @@
 webhooks:
   - name: amocrm
     webhook_path: /testhook
+    projectTags:
+      tagX: Project X
   - name: manychat
     leadSource: ManyChat
     webhook_path: /manychat

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -3,6 +3,8 @@ webhooks:
     webhook_path: /testhook
     projectTags:
       tagX: Project X
+    projectPipelines:
+      Sales: SalesProj
   - name: manychat
     leadSource: ManyChat
     webhook_path: /manychat


### PR DESCRIPTION
## Summary
- add `projectTags` option to AmoCRM config
- route Planfix project based on webhook tags
- document new option in README and example config
- test configuration loading and mapping logic

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6878b34c8110832c9e8545c6954bfbd6