### PR TITLE
Add projectByUtmSource and update project mappings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,3 +5,4 @@
 - Use environment variables only for `CONFIG`, `PORT` and `NODE_ENV`.
 - Create helper functions like `appendTagsByTitle` for config entry like `tagsByTitle`
 - All matchers by config entries `by` should be case-insensitive by config key and taskParams value
+- In README.md add empty line between paragraphs

--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ npm run test-webhook -- <path-to-json>
 The application reads settings from `config.yml`. Override the location with the `CONFIG` environment variable.
 Each webhook entry may specify optional `tags`, `pipeline`, `project` and `leadSource` values which will be added to created tasks if they are not already set.
 For the `amocrm` webhook you can additionally define `projectByTags` and `projectByPipelines` to map specific tags or pipeline names to Planfix projects. Matching is case‑insensitive and treats similar‑looking Latin and Cyrillic letters as the same.
-For Tilda webhooks you can also define `tagsByTitle` to add tags when the form title contains a configured keyword, and `projectByUtmSource` to map UTM sources to Planfix projects.
+
+For Tilda webhooks you can define `tagByTitle` to add a tag when the form title contains a configured keyword, `tagByUtmSource` to map UTM sources to tags, and `projectByUtmSource` to map UTM sources to Planfix projects.
 
 Example:
 
@@ -123,7 +124,9 @@ webhooks:
     leadSource: Tilda
     projectByUtmSource:
       blog: Blog Project
-    tagsByTitle:
+    tagByUtmSource:
+      src: Src Tag
+    tagByTitle:
       "Прямой эфир": "Рег"
 queue:
   max_attempts: 12

--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ npm run test-webhook -- <path-to-json>
 
 The application reads settings from `config.yml`. Override the location with the `CONFIG` environment variable.
 Each webhook entry may specify optional `tags`, `pipeline`, `project` and `leadSource` values which will be added to created tasks if they are not already set.
-For the `amocrm` webhook you can additionally define `projectTags` and `projectPipelines` to map specific tags or pipeline names to Planfix projects. Matching is case‑insensitive and treats similar‑looking Latin and Cyrillic letters as the same.
-For Tilda webhooks you can also define `tagsByTitle` to add tags when the form title contains a configured keyword.
+For the `amocrm` webhook you can additionally define `projectByTags` and `projectByPipelines` to map specific tags or pipeline names to Planfix projects. Matching is case‑insensitive and treats similar‑looking Latin and Cyrillic letters as the same.
+For Tilda webhooks you can also define `tagsByTitle` to add tags when the form title contains a configured keyword, and `projectByUtmSource` to map UTM sources to Planfix projects.
 
 Example:
 
@@ -109,10 +109,10 @@ webhooks:
     pipeline: Sales
     project: Website
     leadSource: AMOCRM
-    projectTags:
+    projectByTags:
       tag1: project1
       other_project: other project
-    projectPipelines:
+    projectByPipelines:
       Sales: Website Sales
       Support: Support Project
   - name: tilda
@@ -121,6 +121,8 @@ webhooks:
     pipeline: Web
     project: Website
     leadSource: Tilda
+    projectByUtmSource:
+      blog: Blog Project
     tagsByTitle:
       "Прямой эфир": "Рег"
 queue:

--- a/data/config-example.yml
+++ b/data/config-example.yml
@@ -27,7 +27,9 @@ webhooks:
     webhook_path: /tilda
     projectByUtmSource:
       blog: Blog Project
-    tagsByTitle:
+    tagByUtmSource:
+      src: Src Tag
+    tagByTitle:
       "Прямой эфир": "Рег"
 queue:
   max_attempts: 12

--- a/data/config-example.yml
+++ b/data/config-example.yml
@@ -6,10 +6,10 @@ webhooks:
     pipeline: Sales
     project: Website
     leadSource: AMOCRM
-    projectTags:
+    projectByTags:
       tag1: project1
       other_project: other project
-    projectPipelines:
+    projectByPipelines:
       Sales: Website Sales
       Support: Support Project
       1000x: 1000x
@@ -25,6 +25,8 @@ webhooks:
     pipeline: Web
     project: Website
     webhook_path: /tilda
+    projectByUtmSource:
+      blog: Blog Project
     tagsByTitle:
       "Прямой эфир": "Рег"
 queue:

--- a/src/handlers/utils.ts
+++ b/src/handlers/utils.ts
@@ -22,4 +22,34 @@ export function appendDefaults(taskParams: any, conf: WebhookDefaults | undefine
   return taskParams;
 }
 
-export default { appendDefaults };
+export function normalizeKey(value: string): string {
+  const cyrMap: Record<string, string> = {
+    'а': 'a',
+    'е': 'e',
+    'ё': 'e',
+    'о': 'o',
+    'р': 'p',
+    'с': 'c',
+    'х': 'x',
+    'у': 'y',
+    'к': 'k',
+    'т': 't',
+    'в': 'b',
+    'м': 'm',
+    'н': 'h',
+  };
+  return value
+    .toLowerCase()
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[аёеорсхуктвмн]/g, ch => cyrMap[ch] || ch);
+}
+
+export function matchByConfig<T>(map: Record<string, T> | undefined, value: string | undefined): T | undefined {
+  if (!map || !value) return undefined;
+  const normMap = Object.fromEntries(
+    Object.entries(map).map(([k, v]) => [normalizeKey(k), v])
+  );
+  return normMap[normalizeKey(value)];
+}
+
+export default { appendDefaults, normalizeKey, matchByConfig };

--- a/tests/amocrm.test.ts
+++ b/tests/amocrm.test.ts
@@ -1,76 +1,76 @@
 import { describe, it, expect } from 'vitest';
-import { applyProjectTags, applyProjectPipelines } from '../src/handlers/amocrm.ts';
+import { applyProjectByTags, applyProjectByPipelines } from '../src/handlers/amocrm.ts';
 
-describe('applyProjectTags', () => {
+describe('applyProjectByTags', () => {
   it('sets project based on tag mapping', () => {
     const params: any = { tags: ['tagX', 'other'] };
     const projectTags = { tagX: 'Project X' };
-    applyProjectTags(params, projectTags);
+    applyProjectByTags(params, projectTags);
     expect(params.project).toBe('Project X');
   });
 
   it('matches tag names case-insensitively', () => {
     const params: any = { tags: ['TAGx'] };
     const projectTags = { tagx: 'Project X' };
-    applyProjectTags(params, projectTags);
+    applyProjectByTags(params, projectTags);
     expect(params.project).toBe('Project X');
   });
 
   it('handles mixed case for config key and tag value', () => {
     const params: any = { tags: ['taG1'] };
     const projectTags = { TAG1: 'Project 1' };
-    applyProjectTags(params, projectTags);
+    applyProjectByTags(params, projectTags);
     expect(params.project).toBe('Project 1');
   });
 
   it('matches cyrillic look-alike letters in tags', () => {
     const params: any = { tags: ['tagХ'] };
     const projectTags = { tagx: 'Project X' };
-    applyProjectTags(params, projectTags);
+    applyProjectByTags(params, projectTags);
     expect(params.project).toBe('Project X');
   });
 
   it('leaves project unchanged when no tag matches', () => {
     const params: any = { tags: ['none'], project: 'Keep' };
     const projectTags = { tagX: 'Project X' };
-    applyProjectTags(params, projectTags);
+    applyProjectByTags(params, projectTags);
     expect(params.project).toBe('Keep');
   });
 });
 
-describe('applyProjectPipelines', () => {
+describe('applyProjectByPipelines', () => {
   it('overrides project based on pipeline', () => {
     const params: any = { pipeline: 'Sales', project: 'Old' };
     const map = { Sales: 'SalesProj' };
-    applyProjectPipelines(params, map);
+    applyProjectByPipelines(params, map);
     expect(params.project).toBe('SalesProj');
   });
 
   it('matches pipeline names case-insensitively', () => {
     const params: any = { pipeline: 'sales', project: 'Old' };
     const map = { Sales: 'SalesProj' };
-    applyProjectPipelines(params, map);
+    applyProjectByPipelines(params, map);
     expect(params.project).toBe('SalesProj');
   });
 
   it('handles mixed case for config key and pipeline value', () => {
     const params: any = { pipeline: 'piPeliNe', project: 'Old' };
     const map = { PipeLine: 'MappedProj' };
-    applyProjectPipelines(params, map);
+    applyProjectByPipelines(params, map);
     expect(params.project).toBe('MappedProj');
   });
 
   it('matches cyrillic look-alike letters in pipeline name', () => {
     const params: any = { pipeline: '1000Х', project: 'Old' };
     const map = { '1000x': '1000x' };
-    applyProjectPipelines(params, map);
+    applyProjectByPipelines(params, map);
     expect(params.project).toBe('1000x');
   });
 
   it('ignores when pipeline not mapped', () => {
     const params: any = { pipeline: 'Other', project: 'Old' };
     const map = { Sales: 'SalesProj' };
-    applyProjectPipelines(params, map);
+    applyProjectByPipelines(params, map);
     expect(params.project).toBe('Old');
   });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -30,5 +30,7 @@ describe('config loader', () => {
   it('loads projectByUtmSource config', () => {
     const tilda = config.webhooks.find(w => w.name === 'tilda') as any;
     expect(tilda.projectByUtmSource.src).toBe('SrcProj');
+    expect(tilda.tagByUtmSource.src).toBe('SrcTag');
+    expect(tilda.tagByTitle['Прямой эфир']).toBe('Рег');
   });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -17,13 +17,18 @@ describe('config loader', () => {
     expect(config.planfix_agent?.url).toBe('http://example.com');
   });
 
-  it('loads projectTags config', () => {
+  it('loads projectByTags config', () => {
     const amo = config.webhooks[0] as any;
-    expect(amo.projectTags.tagX).toBe('Project X');
+    expect(amo.projectByTags.tagX).toBe('Project X');
   });
 
-  it('loads projectPipelines config', () => {
+  it('loads projectByPipelines config', () => {
     const amo = config.webhooks[0] as any;
-    expect(amo.projectPipelines.Sales).toBe('SalesProj');
+    expect(amo.projectByPipelines.Sales).toBe('SalesProj');
+  });
+
+  it('loads projectByUtmSource config', () => {
+    const tilda = config.webhooks.find(w => w.name === 'tilda') as any;
+    expect(tilda.projectByUtmSource.src).toBe('SrcProj');
   });
 });

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -16,7 +16,9 @@ webhooks:
     webhook_path: /tilda
     projectByUtmSource:
       src: SrcProj
-    tagsByTitle:
+    tagByUtmSource:
+      src: SrcTag
+    tagByTitle:
       "Прямой эфир": "Рег"
 queue:
   max_attempts: 2

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -1,9 +1,9 @@
 webhooks:
   - name: amocrm
     webhook_path: /testhook
-    projectTags:
+    projectByTags:
       tagX: Project X
-    projectPipelines:
+    projectByPipelines:
       Sales: SalesProj
   - name: manychat
     leadSource: ManyChat
@@ -14,6 +14,8 @@ webhooks:
     pipeline: Web
     project: Website
     webhook_path: /tilda
+    projectByUtmSource:
+      src: SrcProj
     tagsByTitle:
       "Прямой эфир": "Рег"
 queue:

--- a/tests/tilda.test.ts
+++ b/tests/tilda.test.ts
@@ -104,6 +104,14 @@ describe('tilda handler', () => {
     });
   });
 
+  it('sets project based on utm_source', async () => {
+    const hdrs = {
+      referer: 'https://example.com/page?utm_source=SRC',
+    };
+    const res = await processWebhook({ headers: hdrs, body: { name: 'A' } as any });
+    expect(res.taskParams.project).toBe('SrcProj');
+  });
+
   it('handle test webhook', async () => {
     const res = await processWebhook({ headers, body: { test: 'test' } });
     expect(res.taskParams).toEqual({});

--- a/tests/tilda.test.ts
+++ b/tests/tilda.test.ts
@@ -112,6 +112,14 @@ describe('tilda handler', () => {
     expect(res.taskParams.project).toBe('SrcProj');
   });
 
+  it('adds tag based on utm_source', async () => {
+    const hdrs = {
+      referer: 'https://example.com/page?utm_source=src',
+    };
+    const res = await processWebhook({ headers: hdrs, body: { name: 'A' } as any });
+    expect(res.taskParams.tags).toContain('SrcTag');
+  });
+
   it('handle test webhook', async () => {
     const res = await processWebhook({ headers, body: { test: 'test' } });
     expect(res.taskParams).toEqual({});


### PR DESCRIPTION
## Summary
- support mapping Planfix project from utm_source in Tilda webhooks
- rename AmoCRM project mapping config to `projectByTags` and `projectByPipelines`
- add generic helper functions `normalizeKey` and `matchByConfig`
- update README and example config
- adjust unit tests for new behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878ce07a7d0832cb3d18033d451174e