### PR TITLE
Rename project mapping fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ npm run test-webhook -- <path-to-json>
 
 The application reads settings from `config.yml`. Override the location with the `CONFIG` environment variable.
 Each webhook entry may specify optional `tags`, `pipeline`, `project` and `leadSource` values which will be added to created tasks if they are not already set.
-For the `amocrm` webhook you can additionally define `projectByTags` and `projectByPipelines` to map specific tags or pipeline names to Planfix projects. Matching is case‑insensitive and treats similar‑looking Latin and Cyrillic letters as the same.
+For the `amocrm` webhook you can additionally define `projectByTag` and `projectByPipeline` to map specific tags or pipeline names to Planfix projects. Matching is case‑insensitive and treats similar‑looking Latin and Cyrillic letters as the same.
 
 For Tilda webhooks you can define `tagByTitle` to add a tag when the form title contains a configured keyword, `tagByUtmSource` to map UTM sources to tags, and `projectByUtmSource` to map UTM sources to Planfix projects.
 
@@ -110,10 +110,10 @@ webhooks:
     pipeline: Sales
     project: Website
     leadSource: AMOCRM
-    projectByTags:
+    projectByTag:
       tag1: project1
       other_project: other project
-    projectByPipelines:
+    projectByPipeline:
       Sales: Website Sales
       Support: Support Project
   - name: tilda

--- a/data/config-example.yml
+++ b/data/config-example.yml
@@ -6,10 +6,10 @@ webhooks:
     pipeline: Sales
     project: Website
     leadSource: AMOCRM
-    projectByTags:
+    projectByTag:
       tag1: project1
       other_project: other project
-    projectByPipelines:
+    projectByPipeline:
       Sales: Website Sales
       Support: Support Project
       1000x: 1000x

--- a/src/handlers/amocrm.ts
+++ b/src/handlers/amocrm.ts
@@ -14,8 +14,8 @@ export const webhookName = 'amocrm';
 
 export interface AmocrmConfig extends WebhookItem {
   token?: string;
-  projectByTags?: Record<string, string>;
-  projectByPipelines?: Record<string, string>;
+  projectByTag?: Record<string, string>;
+  projectByPipeline?: Record<string, string>;
 }
 
 const webhookConf = getWebhookConfig(webhookName) as AmocrmConfig;
@@ -233,10 +233,10 @@ function delay(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-export function applyProjectByTags(taskParams, projectByTags) {
-  if (!projectByTags || !Array.isArray(taskParams.tags)) return taskParams;
+export function applyProjectByTag(taskParams, projectByTag) {
+  if (!projectByTag || !Array.isArray(taskParams.tags)) return taskParams;
   for (const tag of taskParams.tags) {
-    const mapped = matchByConfig(projectByTags, tag);
+    const mapped = matchByConfig(projectByTag, tag);
     if (mapped) {
       taskParams.project = mapped;
       break;
@@ -245,9 +245,9 @@ export function applyProjectByTags(taskParams, projectByTags) {
   return taskParams;
 }
 
-export function applyProjectByPipelines(taskParams, projectByPipelines) {
-  if (!projectByPipelines || !taskParams.pipeline) return taskParams;
-  const mapped = matchByConfig(projectByPipelines, taskParams.pipeline);
+export function applyProjectByPipeline(taskParams, projectByPipeline) {
+  if (!projectByPipeline || !taskParams.pipeline) return taskParams;
+  const mapped = matchByConfig(projectByPipeline, taskParams.pipeline);
   if (mapped) taskParams.project = mapped;
   return taskParams;
 }
@@ -305,8 +305,8 @@ async function processWebhook({ headers, body }, queueRow): Promise<ProcessWebho
   }
 
   appendDefaults(taskParams, webhookConf);
-  applyProjectByTags(taskParams, webhookConf?.projectByTags);
-  applyProjectByPipelines(taskParams, webhookConf?.projectByPipelines);
+  applyProjectByTag(taskParams, webhookConf?.projectByTag);
+  applyProjectByPipeline(taskParams, webhookConf?.projectByPipeline);
 
   if (deleted) {
     console.error(`Lead ${leadId} deleted`);

--- a/tests/amocrm.test.ts
+++ b/tests/amocrm.test.ts
@@ -1,76 +1,76 @@
 import { describe, it, expect } from 'vitest';
-import { applyProjectByTags, applyProjectByPipelines } from '../src/handlers/amocrm.ts';
+import { applyProjectByTag, applyProjectByPipeline } from '../src/handlers/amocrm.ts';
 
-describe('applyProjectByTags', () => {
+describe('applyProjectByTag', () => {
   it('sets project based on tag mapping', () => {
     const params: any = { tags: ['tagX', 'other'] };
     const projectTags = { tagX: 'Project X' };
-    applyProjectByTags(params, projectTags);
+    applyProjectByTag(params, projectTags);
     expect(params.project).toBe('Project X');
   });
 
   it('matches tag names case-insensitively', () => {
     const params: any = { tags: ['TAGx'] };
     const projectTags = { tagx: 'Project X' };
-    applyProjectByTags(params, projectTags);
+    applyProjectByTag(params, projectTags);
     expect(params.project).toBe('Project X');
   });
 
   it('handles mixed case for config key and tag value', () => {
     const params: any = { tags: ['taG1'] };
     const projectTags = { TAG1: 'Project 1' };
-    applyProjectByTags(params, projectTags);
+    applyProjectByTag(params, projectTags);
     expect(params.project).toBe('Project 1');
   });
 
   it('matches cyrillic look-alike letters in tags', () => {
     const params: any = { tags: ['tagХ'] };
     const projectTags = { tagx: 'Project X' };
-    applyProjectByTags(params, projectTags);
+    applyProjectByTag(params, projectTags);
     expect(params.project).toBe('Project X');
   });
 
   it('leaves project unchanged when no tag matches', () => {
     const params: any = { tags: ['none'], project: 'Keep' };
     const projectTags = { tagX: 'Project X' };
-    applyProjectByTags(params, projectTags);
+    applyProjectByTag(params, projectTags);
     expect(params.project).toBe('Keep');
   });
 });
 
-describe('applyProjectByPipelines', () => {
+describe('applyProjectByPipeline', () => {
   it('overrides project based on pipeline', () => {
     const params: any = { pipeline: 'Sales', project: 'Old' };
     const map = { Sales: 'SalesProj' };
-    applyProjectByPipelines(params, map);
+    applyProjectByPipeline(params, map);
     expect(params.project).toBe('SalesProj');
   });
 
   it('matches pipeline names case-insensitively', () => {
     const params: any = { pipeline: 'sales', project: 'Old' };
     const map = { Sales: 'SalesProj' };
-    applyProjectByPipelines(params, map);
+    applyProjectByPipeline(params, map);
     expect(params.project).toBe('SalesProj');
   });
 
   it('handles mixed case for config key and pipeline value', () => {
     const params: any = { pipeline: 'piPeliNe', project: 'Old' };
     const map = { PipeLine: 'MappedProj' };
-    applyProjectByPipelines(params, map);
+    applyProjectByPipeline(params, map);
     expect(params.project).toBe('MappedProj');
   });
 
   it('matches cyrillic look-alike letters in pipeline name', () => {
     const params: any = { pipeline: '1000Х', project: 'Old' };
     const map = { '1000x': '1000x' };
-    applyProjectByPipelines(params, map);
+    applyProjectByPipeline(params, map);
     expect(params.project).toBe('1000x');
   });
 
   it('ignores when pipeline not mapped', () => {
     const params: any = { pipeline: 'Other', project: 'Old' };
     const map = { Sales: 'SalesProj' };
-    applyProjectByPipelines(params, map);
+    applyProjectByPipeline(params, map);
     expect(params.project).toBe('Old');
   });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -17,14 +17,14 @@ describe('config loader', () => {
     expect(config.planfix_agent?.url).toBe('http://example.com');
   });
 
-  it('loads projectByTags config', () => {
+  it('loads projectByTag config', () => {
     const amo = config.webhooks[0] as any;
-    expect(amo.projectByTags.tagX).toBe('Project X');
+    expect(amo.projectByTag.tagX).toBe('Project X');
   });
 
-  it('loads projectByPipelines config', () => {
+  it('loads projectByPipeline config', () => {
     const amo = config.webhooks[0] as any;
-    expect(amo.projectByPipelines.Sales).toBe('SalesProj');
+    expect(amo.projectByPipeline.Sales).toBe('SalesProj');
   });
 
   it('loads projectByUtmSource config', () => {

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -1,9 +1,9 @@
 webhooks:
   - name: amocrm
     webhook_path: /testhook
-    projectByTags:
+    projectByTag:
       tagX: Project X
-    projectByPipelines:
+    projectByPipeline:
       Sales: SalesProj
   - name: manychat
     leadSource: ManyChat


### PR DESCRIPTION
## Summary
- rename `projectByTags` to `projectByTag`
- rename `projectByPipelines` to `projectByPipeline`
- update examples, tests and handler functions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fa43bd9b8832cad80b5a2027a123b