### PR TITLE
Add projectByUtmMedium mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ npm run test-webhook -- <path-to-json>
 
 The application reads settings from `config.yml`. Override the location with the `CONFIG` environment variable.
 Each webhook entry may specify optional `tags`, `pipeline`, `project` and `leadSource` values which will be added to created tasks if they are not already set.
-For the `amocrm` webhook you can additionally define `projectByTag` and `projectByPipeline` to map specific tags or pipeline names to Planfix projects. Matching is case‑insensitive and treats similar‑looking Latin and Cyrillic letters as the same.
+For the `amocrm` webhook you can additionally define `projectByTag`, `projectByPipeline` and `projectByUtmMedium` to map specific tags, pipeline names or UTM mediums to Planfix projects. Matching is case‑insensitive and treats similar‑looking Latin and Cyrillic letters as the same.
 
-For Tilda webhooks you can define `tagByTitle` to add a tag when the form title contains a configured keyword, `tagByUtmSource` to map UTM sources to tags, and `projectByUtmSource` to map UTM sources to Planfix projects.
+For Tilda webhooks you can define `tagByTitle` to add a tag when the form title contains a configured keyword, `tagByUtmSource` to map UTM sources to tags, and `projectByUtmSource` or `projectByUtmMedium` to map UTM parameters to Planfix projects.
 
 Example:
 
@@ -116,6 +116,8 @@ webhooks:
     projectByPipeline:
       Sales: Website Sales
       Support: Support Project
+    projectByUtmMedium:
+      blog: Blog Project Medium
   - name: tilda
     webhook_path: /tilda
     tags: [landing]
@@ -124,6 +126,8 @@ webhooks:
     leadSource: Tilda
     projectByUtmSource:
       blog: Blog Project
+    projectByUtmMedium:
+      med: MedProj
     tagByUtmSource:
       src: Src Tag
     tagByTitle:

--- a/data/config-example.yml
+++ b/data/config-example.yml
@@ -13,6 +13,8 @@ webhooks:
       Sales: Website Sales
       Support: Support Project
       1000x: 1000x
+    projectByUtmMedium:
+      blog: Blog Project Medium
   - name: manychat
     leadSource: ManyChat
     tags: [bot]
@@ -27,6 +29,8 @@ webhooks:
     webhook_path: /tilda
     projectByUtmSource:
       blog: Blog Project
+    projectByUtmMedium:
+      med: MedProj
     tagByUtmSource:
       src: Src Tag
     tagByTitle:

--- a/src/handlers/amocrm.ts
+++ b/src/handlers/amocrm.ts
@@ -16,6 +16,7 @@ export interface AmocrmConfig extends WebhookItem {
   token?: string;
   projectByTag?: Record<string, string>;
   projectByPipeline?: Record<string, string>;
+  projectByUtmMedium?: Record<string, string>;
 }
 
 const webhookConf = getWebhookConfig(webhookName) as AmocrmConfig;
@@ -258,6 +259,14 @@ export function applyProjectByPipeline(taskParams, projectByPipeline) {
   return taskParams;
 }
 
+export function applyProjectByUtmMedium(taskParams, projectByUtmMedium) {
+  const medium = taskParams.fields?.utm_medium;
+  if (!projectByUtmMedium || !medium) return taskParams;
+  const mapped = matchByConfig(projectByUtmMedium, medium);
+  if (mapped) taskParams.project = mapped;
+  return taskParams;
+}
+
 async function processWebhook({ headers, body }, queueRow): Promise<ProcessWebhookResult> {
   const token = webhookConf?.token;
   const webhookDelay = (config.queue?.start_delay ?? 5) * 1000;
@@ -313,6 +322,7 @@ async function processWebhook({ headers, body }, queueRow): Promise<ProcessWebho
   appendDefaults(taskParams, webhookConf);
   applyProjectByTag(taskParams, webhookConf?.projectByTag);
   applyProjectByPipeline(taskParams, webhookConf?.projectByPipeline);
+  applyProjectByUtmMedium(taskParams, webhookConf?.projectByUtmMedium);
 
   if (deleted) {
     console.error(`Lead ${leadId} deleted`);

--- a/src/handlers/tilda.ts
+++ b/src/handlers/tilda.ts
@@ -11,6 +11,7 @@ export interface TildaConfig extends WebhookItem {
   tagByTitle?: Record<string, string>;
   tagByUtmSource?: Record<string, string>;
   projectByUtmSource?: Record<string, string>;
+  projectByUtmMedium?: Record<string, string>;
 }
 
 const webhookConf = getWebhookConfig(webhookName) as TildaConfig;
@@ -166,6 +167,14 @@ function applyProjectByUtmSource(taskParams: any, conf = webhookConf): any {
   return taskParams;
 }
 
+function applyProjectByUtmMedium(taskParams: any, conf = webhookConf): any {
+  const medium = taskParams.fields?.utm_medium;
+  if (!medium || !conf?.projectByUtmMedium) return taskParams;
+  const mapped = matchByConfig(conf.projectByUtmMedium, medium);
+  if (mapped) taskParams.project = mapped;
+  return taskParams;
+}
+
 function appendTagByUtmSource(taskParams: any, conf = webhookConf): any {
   const utm = taskParams.fields?.utm_source;
   if (!utm || !conf?.tagByUtmSource) return taskParams;
@@ -188,6 +197,7 @@ export async function processWebhook({ headers = {}, body }: { headers: any; bod
   appendTagsByTitle(taskParams, formTitle, webhookConf);
   appendTagByUtmSource(taskParams, webhookConf);
   applyProjectByUtmSource(taskParams, webhookConf);
+  applyProjectByUtmMedium(taskParams, webhookConf);
   const task = await sendToTargets(taskParams, webhookName);
   return { body, lead: body, taskParams, task };
 }

--- a/tests/amocrm.test.ts
+++ b/tests/amocrm.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { applyProjectByTag, applyProjectByPipeline } from '../src/handlers/amocrm.ts';
+import { applyProjectByTag, applyProjectByPipeline, applyProjectByUtmMedium } from '../src/handlers/amocrm.ts';
 
 describe('applyProjectByTag', () => {
   it('sets project based on tag mapping', () => {
@@ -72,5 +72,28 @@ describe('applyProjectByPipeline', () => {
     const map = { Sales: 'SalesProj' };
     applyProjectByPipeline(params, map);
     expect(params.project).toBe('Old');
+  });
+});
+
+describe('applyProjectByUtmMedium', () => {
+  it('sets project based on utm medium', () => {
+    const params: any = { fields: { utm_medium: 'Med' } };
+    const map = { med: 'MedProj' };
+    applyProjectByUtmMedium(params, map);
+    expect(params.project).toBe('MedProj');
+  });
+
+  it('matches medium names case-insensitively', () => {
+    const params: any = { fields: { utm_medium: 'MED' } };
+    const map = { med: 'MedProj' };
+    applyProjectByUtmMedium(params, map);
+    expect(params.project).toBe('MedProj');
+  });
+
+  it('ignores when medium not mapped', () => {
+    const params: any = { fields: { utm_medium: 'other' }, project: 'Keep' };
+    const map = { med: 'MedProj' };
+    applyProjectByUtmMedium(params, map);
+    expect(params.project).toBe('Keep');
   });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -27,6 +27,13 @@ describe('config loader', () => {
     expect(amo.projectByPipeline.Sales).toBe('SalesProj');
   });
 
+  it('loads projectByUtmMedium config', () => {
+    const amo = config.webhooks[0] as any;
+    const tilda = config.webhooks.find(w => w.name === 'tilda') as any;
+    expect(amo.projectByUtmMedium.med).toBe('MedProj');
+    expect(tilda.projectByUtmMedium.med).toBe('MedProj');
+  });
+
   it('loads projectByUtmSource config', () => {
     const tilda = config.webhooks.find(w => w.name === 'tilda') as any;
     expect(tilda.projectByUtmSource.src).toBe('SrcProj');

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -5,6 +5,8 @@ webhooks:
       tagX: Project X
     projectByPipeline:
       Sales: SalesProj
+    projectByUtmMedium:
+      med: MedProj
   - name: manychat
     leadSource: ManyChat
     webhook_path: /manychat
@@ -16,6 +18,8 @@ webhooks:
     webhook_path: /tilda
     projectByUtmSource:
       src: SrcProj
+    projectByUtmMedium:
+      med: MedProj
     tagByUtmSource:
       src: SrcTag
     tagByTitle:

--- a/tests/tilda.test.ts
+++ b/tests/tilda.test.ts
@@ -135,6 +135,14 @@ describe('tilda handler', () => {
     expect(res.taskParams.project).toBe('SrcProj');
   });
 
+  it('sets project based on utm_medium', async () => {
+    const hdrs = {
+      referer: 'https://example.com/page?utm_medium=MED',
+    };
+    const res = await processWebhook({ headers: hdrs, body: { name: 'A' } as any });
+    expect(res.taskParams.project).toBe('MedProj');
+  });
+
   it('adds tag based on utm_source', async () => {
     const hdrs = {
       referer: 'https://example.com/page?utm_source=src',


### PR DESCRIPTION
## Summary
- map Planfix projects by UTM medium for tilda and amocrm
- document projectByUtmMedium option and show example
- update config example and unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fb8b1f590832c9cbd936f6deba5b5