### PR TITLE
Add project mapping by UTM campaign

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ npm run test-webhook -- <path-to-json>
 
 The application reads settings from `config.yml`. Override the location with the `CONFIG` environment variable.
 Each webhook entry may specify optional `tags`, `pipeline`, `project` and `leadSource` values which will be added to created tasks if they are not already set.
-For the `amocrm` webhook you can additionally define `projectByTag`, `projectByPipeline` and `projectByUtmMedium` to map specific tags, pipeline names or UTM mediums to Planfix projects. Matching is case‑insensitive and treats similar‑looking Latin and Cyrillic letters as the same.
+For the `amocrm` webhook you can additionally define `projectByTag`, `projectByPipeline`, `projectByUtmMedium` or `projectByUtmCampaign` to map specific tags, pipeline names or UTM parameters to Planfix projects. Matching is case‑insensitive and treats similar‑looking Latin and Cyrillic letters as the same.
 
-For Tilda webhooks you can define `tagByTitle` to add a tag when the form title contains a configured keyword, `tagByUtmSource` to map UTM sources to tags, and `projectByUtmSource` or `projectByUtmMedium` to map UTM parameters to Planfix projects.
+For Tilda webhooks you can define `tagByTitle` to add a tag when the form title contains a configured keyword, `tagByUtmSource` to map UTM sources to tags, and `projectByUtmSource`, `projectByUtmMedium` or `projectByUtmCampaign` to map UTM parameters to Planfix projects.
 
 Example:
 
@@ -118,6 +118,8 @@ webhooks:
       Support: Support Project
     projectByUtmMedium:
       blog: Blog Project Medium
+    projectByUtmCampaign:
+      camp: Camp Project
   - name: tilda
     webhook_path: /tilda
     tags: [landing]
@@ -128,6 +130,8 @@ webhooks:
       blog: Blog Project
     projectByUtmMedium:
       med: MedProj
+    projectByUtmCampaign:
+      camp: Camp Project
     tagByUtmSource:
       src: Src Tag
     tagByTitle:

--- a/data/config-example.yml
+++ b/data/config-example.yml
@@ -15,6 +15,8 @@ webhooks:
       1000x: 1000x
     projectByUtmMedium:
       blog: Blog Project Medium
+    projectByUtmCampaign:
+      camp: Camp Project
   - name: manychat
     leadSource: ManyChat
     tags: [bot]
@@ -31,6 +33,8 @@ webhooks:
       blog: Blog Project
     projectByUtmMedium:
       med: MedProj
+    projectByUtmCampaign:
+      camp: Camp Project
     tagByUtmSource:
       src: Src Tag
     tagByTitle:

--- a/src/handlers/utils.ts
+++ b/src/handlers/utils.ts
@@ -52,4 +52,15 @@ export function matchByConfig<T>(map: Record<string, T> | undefined, value: stri
   return normMap[normalizeKey(value)];
 }
 
-export default { appendDefaults, normalizeKey, matchByConfig };
+export function includesByConfig<T>(map: Record<string, T> | undefined, value: string | undefined): T | undefined {
+  if (!map || !value) return undefined;
+  const normValue = normalizeKey(value);
+  for (const [k, v] of Object.entries(map)) {
+    if (normValue.includes(normalizeKey(k))) {
+      return v;
+    }
+  }
+  return undefined;
+}
+
+export default { appendDefaults, normalizeKey, matchByConfig, includesByConfig };

--- a/tests/amocrm.test.ts
+++ b/tests/amocrm.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { applyProjectByTag, applyProjectByPipeline, applyProjectByUtmMedium } from '../src/handlers/amocrm.ts';
+import { applyProjectByTag, applyProjectByPipeline, applyProjectByUtmMedium, applyProjectByUtmCampaign } from '../src/handlers/amocrm.ts';
 
 describe('applyProjectByTag', () => {
   it('sets project based on tag mapping', () => {
@@ -94,6 +94,29 @@ describe('applyProjectByUtmMedium', () => {
     const params: any = { fields: { utm_medium: 'other' }, project: 'Keep' };
     const map = { med: 'MedProj' };
     applyProjectByUtmMedium(params, map);
+    expect(params.project).toBe('Keep');
+  });
+});
+
+describe('applyProjectByUtmCampaign', () => {
+  it('sets project when campaign includes key', () => {
+    const params: any = { fields: { utm_campaign: 'my-camp' } };
+    const map = { camp: 'CampProj' };
+    applyProjectByUtmCampaign(params, map);
+    expect(params.project).toBe('CampProj');
+  });
+
+  it('matches campaign names case-insensitively', () => {
+    const params: any = { fields: { utm_campaign: 'SALE-CAMP' } };
+    const map = { 'sale': 'SaleProj' };
+    applyProjectByUtmCampaign(params, map);
+    expect(params.project).toBe('SaleProj');
+  });
+
+  it('ignores when campaign not mapped', () => {
+    const params: any = { fields: { utm_campaign: 'other' }, project: 'Keep' };
+    const map = { foo: 'FooProj' };
+    applyProjectByUtmCampaign(params, map);
     expect(params.project).toBe('Keep');
   });
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -34,6 +34,13 @@ describe('config loader', () => {
     expect(tilda.projectByUtmMedium.med).toBe('MedProj');
   });
 
+  it('loads projectByUtmCampaign config', () => {
+    const amo = config.webhooks[0] as any;
+    const tilda = config.webhooks.find(w => w.name === 'tilda') as any;
+    expect(amo.projectByUtmCampaign.camp).toBe('CampProj');
+    expect(tilda.projectByUtmCampaign.camp).toBe('CampProj');
+  });
+
   it('loads projectByUtmSource config', () => {
     const tilda = config.webhooks.find(w => w.name === 'tilda') as any;
     expect(tilda.projectByUtmSource.src).toBe('SrcProj');

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -7,6 +7,8 @@ webhooks:
       Sales: SalesProj
     projectByUtmMedium:
       med: MedProj
+    projectByUtmCampaign:
+      camp: CampProj
   - name: manychat
     leadSource: ManyChat
     webhook_path: /manychat
@@ -20,6 +22,8 @@ webhooks:
       src: SrcProj
     projectByUtmMedium:
       med: MedProj
+    projectByUtmCampaign:
+      camp: CampProj
     tagByUtmSource:
       src: SrcTag
     tagByTitle:

--- a/tests/tilda.test.ts
+++ b/tests/tilda.test.ts
@@ -143,6 +143,22 @@ describe('tilda handler', () => {
     expect(res.taskParams.project).toBe('MedProj');
   });
 
+  it('sets project based on utm_campaign substring', async () => {
+    const hdrs = {
+      referer: 'https://example.com/page?utm_campaign=WinterCamp',
+    };
+    const res = await processWebhook({ headers: hdrs, body: { name: 'A' } as any });
+    expect(res.taskParams.project).toBe('CampProj');
+  });
+
+  it('matches campaign names case-insensitively', async () => {
+    const hdrs = {
+      referer: 'https://example.com/page?utm_campaign=sPRING-cAmp',
+    };
+    const res = await processWebhook({ headers: hdrs, body: { name: 'A' } as any });
+    expect(res.taskParams.project).toBe('CampProj');
+  });
+
   it('adds tag based on utm_source', async () => {
     const hdrs = {
       referer: 'https://example.com/page?utm_source=src',


### PR DESCRIPTION
## Summary
- map projects by `utm_campaign` for AMOCRM and Tilda handlers
- support substring matching with `includesByConfig`
- update example configuration and README
- test new configuration and matching logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687fe09ced74832cb77aea93d2167ecb