### PR TITLE
Implement projectByTitle mapping for AmoCRM

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ npm run test-webhook -- <path-to-json>
 
 The application reads settings from `config.yml`. Override the location with the `CONFIG` environment variable.
 Each webhook entry may specify optional `tags`, `pipeline`, `project` and `leadSource` values which will be added to created tasks if they are not already set.
-For the `amocrm` webhook you can additionally define `projectByTag`, `projectByPipeline`, `projectByUtmMedium` or `projectByUtmCampaign` to map specific tags, pipeline names or UTM parameters to Planfix projects. Matching is case‑insensitive and treats similar‑looking Latin and Cyrillic letters as the same.
+For the `amocrm` webhook you can additionally define `projectByTag`, `projectByPipeline`, `projectByTitle`, `projectByUtmMedium` or `projectByUtmCampaign` to map specific tags, pipeline names, lead titles or UTM parameters to Planfix projects. Matching is case‑insensitive and treats similar‑looking Latin and Cyrillic letters as the same.
 
-For Tilda webhooks you can define `tagByTitle` to add a tag when the form title contains a configured keyword, `tagByUtmSource` to map UTM sources to tags, and `projectByUtmSource`, `projectByUtmMedium` or `projectByUtmCampaign` to map UTM parameters to Planfix projects.
+For Tilda webhooks you can define `tagByTitle` to add a tag when the form title contains a configured keyword, `projectByTitle` to choose a project based on the form title, `tagByUtmSource` to map UTM sources to tags, and `projectByUtmSource`, `projectByUtmMedium` or `projectByUtmCampaign` to map UTM parameters to Planfix projects.
 
 Example:
 
@@ -116,6 +116,8 @@ webhooks:
     projectByPipeline:
       Sales: Website Sales
       Support: Support Project
+    projectByTitle:
+      "Запись": FormProj
     projectByUtmMedium:
       blog: Blog Project Medium
     projectByUtmCampaign:
@@ -136,9 +138,11 @@ webhooks:
       src: Src Tag
     tagByTitle:
       "Прямой эфир": "Рег"
-queue:
-  max_attempts: 12
-  start_delay: 1000
+    projectByTitle:
+      "Запись": FormProj
+  queue:
+    max_attempts: 12
+    start_delay: 1000
 planfix_agent:
   token: your_planfix_token
   url: https://planfix.example.com

--- a/data/config-example.yml
+++ b/data/config-example.yml
@@ -13,6 +13,8 @@ webhooks:
       Sales: Website Sales
       Support: Support Project
       1000x: 1000x
+    projectByTitle:
+      "Запись": FormProj
     projectByUtmMedium:
       blog: Blog Project Medium
     projectByUtmCampaign:
@@ -39,9 +41,11 @@ webhooks:
       src: Src Tag
     tagByTitle:
       "Прямой эфир": "Рег"
-queue:
-  max_attempts: 12
-  start_delay: 5
+    projectByTitle:
+      "Запись": FormProj
+  queue:
+    max_attempts: 12
+    start_delay: 5
 planfix_agent:
   token: asd
   url: http://example.com

--- a/src/handlers/amocrm.ts
+++ b/src/handlers/amocrm.ts
@@ -16,6 +16,7 @@ export interface AmocrmConfig extends WebhookItem {
   token?: string;
   projectByTag?: Record<string, string>;
   projectByPipeline?: Record<string, string>;
+  projectByTitle?: Record<string, string>;
   projectByUtmMedium?: Record<string, string>;
   projectByUtmCampaign?: Record<string, string>;
 }
@@ -260,6 +261,21 @@ export function applyProjectByPipeline(taskParams, projectByPipeline) {
   return taskParams;
 }
 
+export function applyProjectByTitle(
+  taskParams: any,
+  title: string | undefined,
+  projectByTitle?: Record<string, string>
+) {
+  if (!projectByTitle || !title) return taskParams;
+  for (const [key, project] of Object.entries(projectByTitle)) {
+    if (title.toLowerCase().includes(key.toLowerCase())) {
+      taskParams.project = project;
+      break;
+    }
+  }
+  return taskParams;
+}
+
 export function applyProjectByUtmMedium(taskParams, projectByUtmMedium) {
   const medium = taskParams.fields?.utm_medium;
   if (!projectByUtmMedium || !medium) return taskParams;
@@ -331,6 +347,7 @@ async function processWebhook({ headers, body }, queueRow): Promise<ProcessWebho
   appendDefaults(taskParams, webhookConf);
   applyProjectByTag(taskParams, webhookConf?.projectByTag);
   applyProjectByPipeline(taskParams, webhookConf?.projectByPipeline);
+  applyProjectByTitle(taskParams, lead.name, webhookConf?.projectByTitle);
   applyProjectByUtmMedium(taskParams, webhookConf?.projectByUtmMedium);
   applyProjectByUtmCampaign(taskParams, webhookConf?.projectByUtmCampaign);
 

--- a/src/handlers/tilda.ts
+++ b/src/handlers/tilda.ts
@@ -10,6 +10,7 @@ export interface TildaConfig extends WebhookItem {
   leadSource?: string;
   tagByTitle?: Record<string, string>;
   tagByUtmSource?: Record<string, string>;
+  projectByTitle?: Record<string, string>;
   projectByUtmSource?: Record<string, string>;
   projectByUtmMedium?: Record<string, string>;
   projectByUtmCampaign?: Record<string, string>;
@@ -160,6 +161,17 @@ function appendTagsByTitle(taskParams: any, formTitle: string | undefined, conf 
   return taskParams;
 }
 
+function applyProjectByTitle(taskParams: any, formTitle: string | undefined, conf = webhookConf): any {
+  if (!formTitle || !conf?.projectByTitle) return taskParams;
+  for (const [title, project] of Object.entries(conf.projectByTitle)) {
+    if (formTitle.toLowerCase().includes(title.toLowerCase())) {
+      taskParams.project = project;
+      break;
+    }
+  }
+  return taskParams;
+}
+
 function applyProjectByUtmSource(taskParams: any, conf = webhookConf): any {
   const utm = taskParams.fields?.utm_source;
   if (!utm || !conf?.projectByUtmSource) return taskParams;
@@ -204,6 +216,7 @@ export async function processWebhook({ headers = {}, body }: { headers: any; bod
   appendDefaults(taskParams, webhookConf);
   const formTitle: string | undefined = body.formname || body.FORMNAME;
   appendTagsByTitle(taskParams, formTitle, webhookConf);
+  applyProjectByTitle(taskParams, formTitle, webhookConf);
   appendTagByUtmSource(taskParams, webhookConf);
   applyProjectByUtmSource(taskParams, webhookConf);
   applyProjectByUtmMedium(taskParams, webhookConf);

--- a/tests/amocrm.test.ts
+++ b/tests/amocrm.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { applyProjectByTag, applyProjectByPipeline, applyProjectByUtmMedium, applyProjectByUtmCampaign } from '../src/handlers/amocrm.ts';
+import { applyProjectByTag, applyProjectByPipeline, applyProjectByTitle, applyProjectByUtmMedium, applyProjectByUtmCampaign } from '../src/handlers/amocrm.ts';
 
 describe('applyProjectByTag', () => {
   it('sets project based on tag mapping', () => {
@@ -72,6 +72,29 @@ describe('applyProjectByPipeline', () => {
     const map = { Sales: 'SalesProj' };
     applyProjectByPipeline(params, map);
     expect(params.project).toBe('Old');
+  });
+});
+
+describe('applyProjectByTitle', () => {
+  it('sets project based on lead title', () => {
+    const params: any = {};
+    const map = { Lead: 'TitleProj' };
+    applyProjectByTitle(params, 'Lead created', map);
+    expect(params.project).toBe('TitleProj');
+  });
+
+  it('matches title case-insensitively', () => {
+    const params: any = {};
+    const map = { leAd: 'TitleProj' };
+    applyProjectByTitle(params, 'lead form', map);
+    expect(params.project).toBe('TitleProj');
+  });
+
+  it('leaves project when no title matches', () => {
+    const params: any = { project: 'Keep' };
+    const map = { abc: 'Proj' };
+    applyProjectByTitle(params, 'other', map);
+    expect(params.project).toBe('Keep');
   });
 });
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -27,6 +27,11 @@ describe('config loader', () => {
     expect(amo.projectByPipeline.Sales).toBe('SalesProj');
   });
 
+  it('loads projectByTitle config', () => {
+    const amo = config.webhooks[0] as any;
+    expect(amo.projectByTitle.Lead).toBe('TitleProj');
+  });
+
   it('loads projectByUtmMedium config', () => {
     const amo = config.webhooks[0] as any;
     const tilda = config.webhooks.find(w => w.name === 'tilda') as any;
@@ -46,5 +51,6 @@ describe('config loader', () => {
     expect(tilda.projectByUtmSource.src).toBe('SrcProj');
     expect(tilda.tagByUtmSource.src).toBe('SrcTag');
     expect(tilda.tagByTitle['Прямой эфир']).toBe('Рег');
+    expect(tilda.projectByTitle['Запись']).toBe('FormProj');
   });
 });

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -5,6 +5,8 @@ webhooks:
       tagX: Project X
     projectByPipeline:
       Sales: SalesProj
+    projectByTitle:
+      Lead: TitleProj
     projectByUtmMedium:
       med: MedProj
     projectByUtmCampaign:
@@ -28,6 +30,8 @@ webhooks:
       src: SrcTag
     tagByTitle:
       "Прямой эфир": "Рег"
+    projectByTitle:
+      "Запись": FormProj
 queue:
   max_attempts: 2
   start_delay: 1000

--- a/tests/tilda.test.ts
+++ b/tests/tilda.test.ts
@@ -18,7 +18,7 @@ const body = {
   userId: '1751020344324579',
   tranid: '7807982:7606836802',
   formid: 'form1069343426',
-  formname: 'Запись эфира'
+  formname: 'Базовая форма'
 };
 
 const expected = {
@@ -26,10 +26,10 @@ const expected = {
   name: 'John Doe Joe',
   email: 'john.doe.joe@example.com',
   phone: '+7 (555) 555-55-55',
-  description: 'Поля:\nreferer: https://example.com/form-page-01\nformname: Запись эфира',
+  description: 'Поля:\nreferer: https://example.com/form-page-01\nformname: Базовая форма',
   fields: {
     referer: 'https://example.com/form-page-01',
-    formname: 'Запись эфира',
+    formname: 'Базовая форма',
   }
 };
 
@@ -58,6 +58,12 @@ describe('tilda handler', () => {
     const matchBody = { name: 'Test', FORMNAME: 'Прямой эфир 16.07' } as any;
     const res = await processWebhook({ headers, body: matchBody });
     expect(res.taskParams.tags).toEqual(['landing', 'Рег']);
+  });
+
+  it('sets project based on form title', async () => {
+    const matchBody = { name: 'Test', formname: 'Запись эфира' } as any;
+    const res = await processWebhook({ headers, body: matchBody });
+    expect(res.taskParams.project).toBe('FormProj');
   });
 
   it('handles capitalized field names and telegram field', () => {


### PR DESCRIPTION
## Summary
- support `projectByTitle` mapping in AmoCRM handler
- update documentation and config examples
- extend config and AmoCRM tests for new mapping

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6889d7b35014832cba5c66f3b2c12e11