### PR TITLE
Add telegram detection and ignore fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ For the `amocrm` webhook you can additionally define `projectByTag`, `projectByP
 
 For Tilda webhooks you can define `tagByTitle` to add a tag when the form title contains a configured keyword, `projectByTitle` to choose a project based on the form title, `tagByUtmSource` to map UTM sources to tags, and `projectByUtmSource`, `projectByUtmMedium` or `projectByUtmCampaign` to map UTM parameters to Planfix projects.
 
+Both handlers also support an `ignoreFields` option listing form fields that should be skipped when building the task description. By default the fields `TRANID`, `_ym_uid`, `FORMID` and `COOKIES` are ignored.
+
 Example:
 
 ```yml
@@ -122,6 +124,11 @@ webhooks:
       blog: Blog Project Medium
     projectByUtmCampaign:
       camp: Camp Project
+    ignoreFields:
+      - TRANID
+      - _ym_uid
+      - FORMID
+      - COOKIES
   - name: tilda
     webhook_path: /tilda
     tags: [landing]
@@ -134,6 +141,11 @@ webhooks:
       med: MedProj
     projectByUtmCampaign:
       camp: Camp Project
+    ignoreFields:
+      - TRANID
+      - _ym_uid
+      - FORMID
+      - COOKIES
     tagByUtmSource:
       src: Src Tag
     tagByTitle:

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,7 @@ export interface WebhookItem {
   pipeline?: string;
   project?: string;
   leadSource?: string;
+  ignoreFields?: string[];
 }
 export interface QueueConfig { max_attempts?: number; start_delay?: number; }
 export interface PlanfixAgentConfig { token?: string; url?: string; }
@@ -31,6 +32,13 @@ const defaultPath = path.join(process.cwd(), 'data', 'config.yml');
 const configPath = process.env.CONFIG || defaultPath;
 
 export const config: Config = yaml.load(fs.readFileSync(configPath, 'utf8')) as Config;
+
+const DEFAULT_IGNORE_FIELDS = ['TRANID', '_ym_uid', 'FORMID', 'COOKIES'];
+for (const wh of config.webhooks) {
+  if ((wh.name === 'amocrm' || wh.name === 'tilda') && !wh.ignoreFields) {
+    wh.ignoreFields = DEFAULT_IGNORE_FIELDS;
+  }
+}
 
 export function getWebhookConfig(name: string): WebhookItem | undefined {
   return config.webhooks.find(w => w.name === name);

--- a/src/handlers/amocrm.ts
+++ b/src/handlers/amocrm.ts
@@ -221,6 +221,11 @@ function extractTaskParams(lead, contacts, detailedContacts, baseUrl, managerEma
       if (norm === "utm_source") utm.utm_source = values.join(", ");
       if (norm === "utm_medium") utm.utm_medium = values.join(", ");
       if (norm === "utm_campaign") utm.utm_campaign = values.join(", ");
+
+      // telegram
+      if (/telegram|телеграм/i.test(name)) {
+        params.telegram = values.join(", ");
+      }
     }
   }
   Object.assign(fields, utm);

--- a/src/handlers/amocrm.ts
+++ b/src/handlers/amocrm.ts
@@ -19,6 +19,7 @@ export interface AmocrmConfig extends WebhookItem {
   projectByTitle?: Record<string, string>;
   projectByUtmMedium?: Record<string, string>;
   projectByUtmCampaign?: Record<string, string>;
+  ignoreFields?: string[];
 }
 
 const webhookConf = getWebhookConfig(webhookName) as AmocrmConfig;
@@ -180,6 +181,15 @@ function extractTaskParams(lead, contacts, detailedContacts, baseUrl, managerEma
         const tg = f.values.find((v) => v.enum_code === "TELEGRAM");
         if (tg) params.telegram = tg.value;
       }
+      if (
+        !params.telegram &&
+        Array.isArray(f.values) &&
+        f.values[0] &&
+        ((typeof f.field_name === 'string' && /telegram|телеграм/i.test(f.field_name)) ||
+          (typeof f.field_code === 'string' && /telegram|телеграм/i.test(f.field_code)))
+      ) {
+        params.telegram = f.values[0].value;
+      }
     }
   }
 
@@ -192,9 +202,15 @@ function extractTaskParams(lead, contacts, detailedContacts, baseUrl, managerEma
   const customLines = [];
   const fields: Record<string, string> = {};
   const utm: Record<string, string> = {};
+  const ignored = new Set(
+    (webhookConf?.ignoreFields ?? ['TRANID', '_ym_uid', 'FORMID', 'COOKIES']).map(
+      (n) => n.toLowerCase()
+    )
+  );
   for (const f of customFields) {
     const name = f.field_name || f.name || f.field_code;
     if (!name) continue;
+    if (ignored.has(String(name).toLowerCase())) continue;
     const values = Array.isArray(f.values)
       ? f.values.map((v) => v.value).filter(Boolean)
       : [];

--- a/src/handlers/tilda.ts
+++ b/src/handlers/tilda.ts
@@ -14,6 +14,7 @@ export interface TildaConfig extends WebhookItem {
   projectByUtmSource?: Record<string, string>;
   projectByUtmMedium?: Record<string, string>;
   projectByUtmCampaign?: Record<string, string>;
+  ignoreFields?: string[];
 }
 
 const webhookConf = getWebhookConfig(webhookName) as TildaConfig;
@@ -117,8 +118,9 @@ export function extractTaskParams(body: any, headers: any): any {
     'telegram',
     'reflinkid',
     'userid',
-    'tranid',
-    'formid',
+    ...(
+      webhookConf?.ignoreFields ?? ['TRANID', '_ym_uid', 'FORMID', 'COOKIES']
+    ).map((v) => v.toLowerCase()),
   ]);
   for (const [key, value] of Object.entries(body)) {
     const keyLower = key.toLowerCase();

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -53,4 +53,21 @@ describe('config loader', () => {
     expect(tilda.tagByTitle['Прямой эфир']).toBe('Рег');
     expect(tilda.projectByTitle['Запись']).toBe('FormProj');
   });
+
+  it('loads ignoreFields defaults', () => {
+    const amo = config.webhooks[0] as any;
+    const tilda = config.webhooks.find(w => w.name === 'tilda') as any;
+    expect(amo.ignoreFields).toEqual([
+      'TRANID',
+      '_ym_uid',
+      'FORMID',
+      'COOKIES',
+    ]);
+    expect(tilda.ignoreFields).toEqual([
+      'TRANID',
+      '_ym_uid',
+      'FORMID',
+      'COOKIES',
+    ]);
+  });
 });

--- a/tests/tilda.test.ts
+++ b/tests/tilda.test.ts
@@ -89,6 +89,18 @@ describe('tilda handler', () => {
     });
   });
 
+  it('ignores default extra fields', () => {
+    const extraBody = {
+      name: 'A',
+      TRANID: '1',
+      _ym_uid: '2',
+      FORMID: '3',
+      COOKIES: 'c',
+    } as any;
+    const params = extractTaskParams(extraBody, headers);
+    expect(params.fields).toEqual({ referer: headers.referer });
+  });
+
   it('uses default name when not provided', () => {
     const noNameBody = { email: 'a@b.com', phone: '123', formname: 'Form' };
     const params = extractTaskParams(noNameBody, headers);


### PR DESCRIPTION
## Summary
- detect Telegram contact field in amoCRM handler
- skip fields defined in `ignoreFields` for amoCRM and Tilda handlers
- support default `ignoreFields` in config loader
- document `ignoreFields` option in README
- test default ignore fields for Tilda
- verify ignoreFields loaded by config

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889e4fae320832cbc75bb1f0952d0b6