### PR TITLE
Add dynamic config loading

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -28,9 +28,16 @@ export interface Config {
 }
 
 const defaultPath = path.join(process.cwd(), 'data', 'config.yml');
-const configPath = process.env.CONFIG || defaultPath;
+export const configPath = process.env.CONFIG || defaultPath;
 
-export const config: Config = yaml.load(fs.readFileSync(configPath, 'utf8')) as Config;
+export let config: Config;
+
+export function loadConfig(): Config {
+  config = yaml.load(fs.readFileSync(configPath, 'utf8')) as Config;
+  return config;
+}
+
+loadConfig();
 
 export function getWebhookConfig(name: string): WebhookItem | undefined {
   return config.webhooks.find(w => w.name === name);

--- a/src/handlers/manychat.ts
+++ b/src/handlers/manychat.ts
@@ -10,7 +10,9 @@ export interface ManychatConfig extends WebhookItem {
   leadSource?: string;
 }
 
-const webhookConf = getWebhookConfig(webhookName) as ManychatConfig;
+function webhookConf(): ManychatConfig | undefined {
+  return getWebhookConfig(webhookName) as ManychatConfig;
+}
 
 export function extractLeadDetails(body: any): { lead: any } {
   return { lead: body.contact || {} };
@@ -18,7 +20,7 @@ export function extractLeadDetails(body: any): { lead: any } {
 
 export function extractTaskParams(lead: any): any {
   const contact = lead || {};
-  const params: any = { leadSource: webhookConf?.leadSource || 'ManyChat' };
+  const params: any = { leadSource: webhookConf()?.leadSource || 'ManyChat' };
 
   const name = contact.name || contact.ig_username || (contact.ig_id ? `Instagram id ${contact.ig_id}` : undefined);
   if (name) params.name = name;
@@ -52,7 +54,7 @@ export function extractTaskParams(lead: any): any {
 export async function processWebhook({ headers, body }: { headers: any; body: any }): Promise<ProcessWebhookResult> {
   const { lead } = extractLeadDetails(body);
   const taskParams = extractTaskParams(lead);
-  appendDefaults(taskParams, webhookConf);
+  appendDefaults(taskParams, webhookConf());
 
   const task = await sendToTargets(taskParams, webhookName);
 

--- a/src/target.ts
+++ b/src/target.ts
@@ -1,9 +1,10 @@
 import fetch from 'node-fetch';
-import { config } from './config.js';
+import { loadConfig } from './config.js';
 
 export async function createPlanfixTask(taskParams: any) {
-  const agentToken = config.planfix_agent?.token;
-  const url = config.planfix_agent?.url;
+  const cfg = loadConfig();
+  const agentToken = cfg.planfix_agent?.token;
+  const url = cfg.planfix_agent?.url;
   if (!agentToken) {
     throw new Error('planfix_agent.token is required');
   }
@@ -36,8 +37,9 @@ export async function sendTelegramMessage(
   webhookName = '',
   task: any = null
 ) {
-  if (!config.telegram) return null;
-  const { bot_token: botToken, chat_id: chatId } = config.telegram;
+  const cfg = loadConfig();
+  if (!cfg.telegram) return null;
+  const { bot_token: botToken, chat_id: chatId } = cfg.telegram;
   if (!botToken || !chatId) return null;
 
   let text = (taskParams.description || '').trim();

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,12 +1,14 @@
 import './logger.js';
 import 'dotenv/config';
 import { processQueue } from './queue.js';
-import { config } from './config.js';
+import fs from 'fs';
+import { loadConfig, configPath } from './config.js';
 import { fileURLToPath } from 'url';
 
 function validateTargetConfig() {
-  const url = config.planfix_agent?.url;
-  const token = config.planfix_agent?.token;
+  const cfg = loadConfig();
+  const url = cfg.planfix_agent?.url;
+  const token = cfg.planfix_agent?.token;
   if (!url || !token) {
     console.error('Missing planfix_agent.url or planfix_agent.token');
     process.exit(1);
@@ -17,6 +19,11 @@ export async function start() {
   console.log('Worker started');
   await processQueue();
 }
+
+fs.watchFile(configPath, () => {
+  console.log('Config file changed, reloading');
+  loadConfig();
+});
 
 const filename = fileURLToPath(import.meta.url);
 if (process.argv[1] === filename) {

--- a/tests/reload.test.ts
+++ b/tests/reload.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import fs from 'fs';
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+afterEach(() => {
+  vi.unmock('fs');
+});
+
+describe('config reload watching', () => {
+  it('reloads config when file changes in index.ts', async () => {
+    const watchSpy = vi.spyOn(fs, 'watchFile');
+    const original = process.argv[1];
+    process.argv[1] = fileURLToPath(new URL('../src/index.ts', import.meta.url));
+    const configMod = await import('../src/config.ts');
+    const loadSpy = vi.spyOn(configMod, 'loadConfig');
+    await import('../src/index.ts');
+    expect(watchSpy).toHaveBeenCalled();
+    const cb = watchSpy.mock.calls[0][1];
+    loadSpy.mockClear();
+    cb();
+    expect(loadSpy).toHaveBeenCalled();
+    process.argv[1] = original;
+  });
+
+  it('reloads config when file changes in worker.ts', async () => {
+    const watchSpy = vi.spyOn(fs, 'watchFile');
+    const original = process.argv[1];
+    process.argv[1] = fileURLToPath(new URL('../src/worker.ts', import.meta.url));
+    const configMod = await import('../src/config.ts');
+    const loadSpy = vi.spyOn(configMod, 'loadConfig');
+    await import('../src/worker.ts');
+    expect(watchSpy).toHaveBeenCalled();
+    const cb = watchSpy.mock.calls[0][1];
+    loadSpy.mockClear();
+    cb();
+    expect(loadSpy).toHaveBeenCalled();
+    process.argv[1] = original;
+  });
+});


### PR DESCRIPTION
## Summary
- parse configuration through `loadConfig()` in `src/config.ts`
- watch configuration file and reload settings on change
- call `loadConfig()` where config is required
- add tests for watching the config file

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889dbfb2f18832c8e9fc8dadf283c29