### PR TITLE
feat: tag telegram errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ For Tilda webhooks you can define `tagByTitle` to add a tag when the form title 
 
 Both handlers also support an `ignoreFields` option listing form fields that should be skipped when building the task description. By default the fields `TRANID`, `_ym_uid`, `FORMID` and `COOKIES` are ignored.
 
+Telegram notifications are configured in the `telegram` section with `bot_name`, `bot_token` and `chat_id`.
+You can also set `error_text` to append a message when a Planfix task is not created.
+
 Example:
 
 ```yml
@@ -162,6 +165,7 @@ telegram:
   bot_name: example_bot
   bot_token: token
   chat_id: 123456
+  error_text: PF task failed
 ```
 
 ## Environment Variables

--- a/data/config-example.yml
+++ b/data/config-example.yml
@@ -53,4 +53,5 @@ telegram:
   bot_name: example_bot
   bot_token: token
   chat_id: 123456
+  error_text: "Error creating task"
 proxy_url: http://host:port

--- a/src/config.ts
+++ b/src/config.ts
@@ -18,6 +18,7 @@ export interface TelegramConfig {
   bot_name: string;
   bot_token: string;
   chat_id: string;
+  error_text?: string;
 }
 
 export interface Config {

--- a/src/handlers/amocrm.ts
+++ b/src/handlers/amocrm.ts
@@ -382,17 +382,19 @@ async function processWebhook({ headers, body }, queueRow): Promise<ProcessWebho
   if (contacts.length === 0) {
     console.error(`Failed to retrieve lead details for lead ID: ${leadId}`);
     // create task first, then waiting for contacts appears 
-    if (queueRow.attempts > 0) {
+    if (queueRow?.attempts > 0) {
       throw new Error(`Failed to retrieve lead details for lead ID: ${leadId}`);
     }
   }
 
 
   // Create task in Planfix
-  const task = await sendToTargets(taskParams, webhookName);
   if (contacts.length === 0) {
-    throw new Error(`Lead ${leadId} has no contacts`);
+    if (!taskParams.tags) taskParams.tags = [];
+    if (!taskParams.tags.includes('error')) taskParams.tags.push('error');
+    // throw new Error(`Lead ${leadId} has no contacts`);
   }
+  const task = await sendToTargets(taskParams, webhookName);
 
   return { body, lead, taskParams, task };
 }

--- a/src/target.ts
+++ b/src/target.ts
@@ -39,8 +39,13 @@ export async function sendTelegramMessage(
 ) {
   const cfg = loadConfig();
   if (!cfg.telegram) return null;
-  const { bot_token: botToken, chat_id: chatId } = cfg.telegram;
+  const { bot_token: botToken, chat_id: chatId, error_text: errorText } = cfg.telegram;
   if (!botToken || !chatId) return null;
+
+  if (!task) {
+    if (!Array.isArray(taskParams.tags)) taskParams.tags = [];
+    if (!taskParams.tags.includes('error')) taskParams.tags.push('error');
+  }
 
   let text = (taskParams.description || '').trim();
   if (!text) {
@@ -66,6 +71,10 @@ export async function sendTelegramMessage(
 
   if (task?.url) {
     text = `${text}\n\nПланфикс:\n${task.url}`;
+  }
+
+  if (!task && errorText) {
+    text = `${text}\n\n${errorText}`;
   }
 
   if (Array.isArray(taskParams.tags) && taskParams.tags.length) {

--- a/src/target.ts
+++ b/src/target.ts
@@ -72,8 +72,12 @@ export async function sendTelegramMessage(
   if (task?.url) {
     text = `${text}\n\nПланфикс:\n${task.url}`;
   }
+  else {
+    if (!taskParams.tags) taskParams.tags = [];
+    if (!taskParams.tags.includes('error')) taskParams.tags.push('error');
+  }
 
-  if (!task && errorText) {
+  if (taskParams.tags.includes('error') && errorText) {
     text = `${text}\n\n${errorText}`;
   }
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -11,6 +11,7 @@ describe('config loader', () => {
   it('loads telegram config', () => {
     expect(config.telegram.bot_name).toBe('example_bot');
     expect(config.telegram.chat_id).toBe('example_chat');
+    expect(config.telegram.error_text).toBe('Test error');
   });
 
   it('loads planfix agent config', () => {

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -42,3 +42,4 @@ telegram:
   bot_name: example_bot
   bot_token: token
   chat_id: example_chat
+  error_text: Test error

--- a/tests/telegram.test.ts
+++ b/tests/telegram.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('node-fetch', () => ({
+  default: vi.fn(async () => ({ ok: true, json: async () => ({}) }))
+}));
+
+import fetch from 'node-fetch';
+import { sendTelegramMessage } from '../src/target.ts';
+
+describe('sendTelegramMessage', () => {
+  it('adds error tag and text when no task', async () => {
+    const params: any = { description: 'Hello', tags: ['foo'] };
+    await sendTelegramMessage(params);
+    expect(params.tags).toContain('error');
+    const body = JSON.parse((fetch as any).mock.calls[0][1].body);
+    expect(body.text).toBe('Hello\n\nTest error\n\n#foo #error');
+  });
+});


### PR DESCRIPTION
## Summary
- tag error telegram messages when Planfix task is missing
- allow configuring error_text and document telegram section
- cover telegram error handling with unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689320c700d4832c8a71c79edfa0f32b