### PR TITLE
refactor: centralize handler types and utilities

### DIFF
--- a/src/handlers/_example.ts
+++ b/src/handlers/_example.ts
@@ -1,7 +1,7 @@
 import { sendToTargets } from '../target.js';
 import { getWebhookConfig } from '../config.js';
-import { appendDefaults } from './utils.js';
-import type { ProcessWebhookResult } from './types.js';
+import { appendDefaults } from '../utils.js';
+import type { ProcessWebhookResult } from '../types/handlers.js';
 import type { WebhookItem } from '../config.js';
 
 export const webhookName = '_example';

--- a/src/handlers/amocrm.ts
+++ b/src/handlers/amocrm.ts
@@ -5,9 +5,9 @@ import fs from 'fs';
 import path from 'path';
 import { loadConfig, getWebhookConfig } from '../config.js';
 import { sendToTargets } from '../target.js';
-import { appendDefaults, matchByConfig, normalizeKey, includesByConfig } from './utils.js';
+import { appendDefaults, matchByConfig, normalizeKey, includesByConfig } from '../utils.js';
 import type { WebhookItem } from '../config.js';
-import type { ProcessWebhookResult } from './types.js';
+import type { ProcessWebhookResult } from '../types/handlers.js';
 import { fileURLToPath } from 'url';
 
 export const webhookName = 'amocrm';

--- a/src/handlers/manychat.ts
+++ b/src/handlers/manychat.ts
@@ -1,8 +1,8 @@
 import { getWebhookConfig } from '../config.js';
 import { sendToTargets } from '../target.js';
-import { appendDefaults } from './utils.js';
+import { appendDefaults } from '../utils.js';
 import type { WebhookItem } from '../config.js';
-import type { ProcessWebhookResult } from './types.js';
+import type { ProcessWebhookResult } from '../types/handlers.js';
 
 export const webhookName = 'manychat';
 

--- a/src/handlers/tilda.ts
+++ b/src/handlers/tilda.ts
@@ -1,7 +1,7 @@
 import { sendToTargets } from '../target.js';
 import { getWebhookConfig } from '../config.js';
-import { appendDefaults, matchByConfig, includesByConfig } from './utils.js';
-import type { ProcessWebhookResult } from './types.js';
+import { appendDefaults, matchByConfig, includesByConfig } from '../utils.js';
+import type { ProcessWebhookResult } from '../types/handlers.js';
 import type { WebhookItem } from '../config.js';
 
 export const webhookName = 'tilda';

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import crypto from 'crypto';
 import Database from 'better-sqlite3';
 import { loadConfig } from './config.js';
-import type { ProcessWebhook } from './handlers/types.js';
+import type { ProcessWebhook } from './types/handlers.js';
 
 const DB_DIR = path.join(process.cwd(), 'data');
 const DB_PATH = path.join(DB_DIR, 'webhooks.db');

--- a/src/types/handlers.ts
+++ b/src/types/handlers.ts
@@ -8,3 +8,4 @@ export interface ProcessWebhookResult {
 export interface ProcessWebhook {
   (input: { headers: any; body: any }, row?: any): Promise<ProcessWebhookResult>;
 }
+

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -64,3 +64,4 @@ export function includesByConfig<T>(map: Record<string, T> | undefined, value: s
 }
 
 export default { appendDefaults, normalizeKey, matchByConfig, includesByConfig };
+


### PR DESCRIPTION
## Summary
- move ProcessWebhook types to global module
- move webhook helper functions to shared utils

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad605e55e8832c83332347fc04db60